### PR TITLE
Function call signatures

### DIFF
--- a/core/src/BinaryBitmap.h
+++ b/core/src/BinaryBitmap.h
@@ -22,7 +22,6 @@ namespace ZXing {
 
 class BitArray;
 class BitMatrix;
-enum class DecodeStatus;
 
 /**
 * This class is the core bitmap class used by ZXing to represent 1 bit data. Reader objects

--- a/core/src/BinaryBitmap.h
+++ b/core/src/BinaryBitmap.h
@@ -60,7 +60,7 @@ public:
 	* @return The array of bits for this row (true means black).
 	* @throws NotFoundException if row can't be binarized
 	*/
-	virtual DecodeStatus getBlackRow(int y, BitArray& outArray) const = 0;
+	virtual bool getBlackRow(int y, BitArray& outArray) const = 0;
 
 	/**
 	* Converts a 2D array of luminance data to 1 bit. This method is intended for decoding 2D

--- a/core/src/BitWrapperBinarizer.cpp
+++ b/core/src/BitWrapperBinarizer.cpp
@@ -55,7 +55,7 @@ BitWrapperBinarizer::height() const
 }
 
 // Applies simple sharpening to the row data to improve performance of the 1D Readers.
-DecodeStatus
+bool
 BitWrapperBinarizer::getBlackRow(int y, BitArray& row) const
 {
 	if (y < 0 || y >= _height) {
@@ -70,7 +70,7 @@ BitWrapperBinarizer::getBlackRow(int y, BitArray& row) const
 		_matrix->getRow(_top + y, tmp);
 		tmp.getSubArray(_left, _width, row);
 	}
-	return DecodeStatus::NoError;
+	return true;
 }
 
 // Does not sharpen the data, as this call is intended to only be used by 2D Readers.

--- a/core/src/BitWrapperBinarizer.h
+++ b/core/src/BitWrapperBinarizer.h
@@ -32,7 +32,7 @@ public:
 	bool isPureBarcode() const override;
 	int width() const override;
 	int height() const override;
-	DecodeStatus getBlackRow(int y, BitArray& row) const override;
+	bool getBlackRow(int y, BitArray& row) const override;
 	std::shared_ptr<const BitMatrix> getBlackMatrix() const override;
 	bool canCrop() const override;
 	std::shared_ptr<BinaryBitmap> cropped(int left, int top, int width, int height) const override;

--- a/core/src/DecodeHints.h
+++ b/core/src/DecodeHints.h
@@ -22,7 +22,6 @@
 namespace ZXing {
 
 enum class BarcodeFormat;
-//typedef std::function<void(float x, float y)> PointCallback;
 
 class DecodeHints
 {
@@ -63,18 +62,6 @@ public:
 	void setCharacterSet(const std::string& charset) {
 		_charset = charset;
 	}
-
-	/**
-	* The caller needs to be notified via callback when a possible {@link ResultPoint}
-	* is found.
-	*/
-	/*PointCallback resultPointCallback() const {
-		return _callback;
-	}*/
-
-	/*void setResultPointCallback(const PointCallback& callback) {
-		_callback = callback;
-	}*/
 
 	/**
 	* Allowed lengths of encoded data -- reject anything else..
@@ -141,7 +128,6 @@ public:
 private:
 	uint32_t _flags = 0;
 	std::string _charset;
-	//PointCallback _callback;
 	std::vector<int> _lengths;
 	std::vector<int> _eanExts;
 

--- a/core/src/DecodeStatus.cpp
+++ b/core/src/DecodeStatus.cpp
@@ -19,11 +19,5 @@
 
 namespace ZXing {
 
-bool
-StatusIsKindOf(DecodeStatus status, DecodeStatus group)
-{
-	int shift = BitHacks::NumberOfTrailingZeros(static_cast<uint32_t>(group));
-	return (static_cast<uint32_t>(status) >> shift) == (static_cast<uint32_t>(group) >> shift);
-}
 
 } // ZXing

--- a/core/src/DecodeStatus.h
+++ b/core/src/DecodeStatus.h
@@ -20,8 +20,6 @@ namespace ZXing {
 enum class DecodeStatus
 {
 	NoError = 0,
-
-	ReaderError = 0x10,
 	NotFound,
 	FormatError,
 	ChecksumError,
@@ -36,7 +34,5 @@ inline bool StatusIsError(DecodeStatus status)
 {
 	return status != DecodeStatus::NoError;
 }
-
-bool StatusIsKindOf(DecodeStatus status, DecodeStatus group);
 
 } // ZXing

--- a/core/src/DecodeStatus.h
+++ b/core/src/DecodeStatus.h
@@ -25,12 +25,6 @@ enum class DecodeStatus
 	NotFound,
 	FormatError,
 	ChecksumError,
-
-	ReedSolomonError = 0x20,
-	ReedSolomonAlgoFailed,		// r_{i-1} was zero
-	ReedSolomonBadLocation,		// Bad error location
-	ReedSolomonDegreeMismatch,	// Error locator degree does not match number of roots
-	ReedSolomonSigmaTildeZero,	// sigmaTilde(0) was zero
 };
 
 inline bool StatusIsOK(DecodeStatus status)

--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -17,6 +17,7 @@
 */
 
 #include "ByteArray.h"
+#include "DecodeStatus.h"
 
 #include <memory>
 #include <list>
@@ -35,6 +36,7 @@ class CustomData;
 */
 class DecoderResult
 {
+	DecodeStatus _status = DecodeStatus::NoError;
 	ByteArray _rawBytes;
 	int _numBits = 0;
 	std::wstring _text;
@@ -50,9 +52,15 @@ public:
 	//explicit DecoderResult(DecodeStatus status);
 	//DecoderResult(const ByteArray& rawBytes, const String& text, std::list<ByteArray>& byteSegments, const std::string& ecLevel, int saSequence, int saParity);
 	//DecoderResult(const ByteArray& rawBytes, const String& text, std::list<ByteArray>& byteSegments, const std::string& ecLevel);
-	DecoderResult() {}
+	DecoderResult(DecodeStatus status) : _status(status) {}
+	DecoderResult() = default;
 	DecoderResult(const DecoderResult &) = delete;
 	DecoderResult& operator=(const DecoderResult &) = delete;
+	DecoderResult(DecoderResult&&) = default;
+	DecoderResult& operator=(DecoderResult&&) = default;
+
+	bool isValid() const { return StatusIsOK(_status); }
+	DecodeStatus errorCode() const { return _status; }
 
 	const ByteArray& rawBytes() const { return _rawBytes; }
 	void setRawBytes(const ByteArray& bytes) { _rawBytes = bytes; _numBits = 8 * bytes.length(); }

--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -48,14 +48,16 @@ class DecoderResult
 	int _structuredAppendParity = 0;
 	std::shared_ptr<CustomData> _extra;
 
-public:
-	//explicit DecoderResult(DecodeStatus status);
-	//DecoderResult(const ByteArray& rawBytes, const String& text, std::list<ByteArray>& byteSegments, const std::string& ecLevel, int saSequence, int saParity);
-	//DecoderResult(const ByteArray& rawBytes, const String& text, std::list<ByteArray>& byteSegments, const std::string& ecLevel);
-	DecoderResult(DecodeStatus status) : _status(status) {}
-	DecoderResult() = default;
 	DecoderResult(const DecoderResult &) = delete;
 	DecoderResult& operator=(const DecoderResult &) = delete;
+
+public:
+	DecoderResult(DecodeStatus status) : _status(status) {}
+	DecoderResult(ByteArray&& rawBytes, std::wstring&& text) : _rawBytes(std::move(rawBytes)), _text(std::move(text)) {
+		_numBits = 8 * rawBytes.length();
+	}
+
+	DecoderResult() = default;
 	DecoderResult(DecoderResult&&) = default;
 	DecoderResult& operator=(DecoderResult&&) = default;
 
@@ -63,35 +65,34 @@ public:
 	DecodeStatus errorCode() const { return _status; }
 
 	const ByteArray& rawBytes() const { return _rawBytes; }
-	void setRawBytes(const ByteArray& bytes) { _rawBytes = bytes; _numBits = 8 * bytes.length(); }
-	int numBits() const { return _numBits; }
-	void setNumBits(int numBits) { _numBits = numBits; }
-
 	const std::wstring& text() const { return _text; }
-	void setText(const std::wstring& txt) { _text = txt; }
 
-	const std::list<ByteArray>& byteSegments() const { return _byteSegments; }
-	void setByteSegments(const std::list<ByteArray>& segments) { _byteSegments = segments; }
+	// Simple macro to set up getter/setter methods that save lots of boilerplate.
+	// It sets up a standard 'const & () const', 2 setters for setting lvalues via
+	// copy and 2 for setting rvalues via move. They are provided each to work
+	// either on lvalues (normal 'void (...)') or on rvalues (returning '*this' as
+	// rvalue). The latter can be used to optionally initialize a temporary in a
+	// return statement, e.g.
+	//    return DecoderResult(bytes, text).setEcLevel(level);
+#define PROPERTY(TYPE, GETTER, SETTER) \
+	const TYPE& GETTER() const { return _##GETTER; } \
+	void SETTER(const TYPE& v) & { _##GETTER = v; } \
+	void SETTER(TYPE&& v) & { _##GETTER = std::move(v); } \
+	DecoderResult&& SETTER(const TYPE& v) && { _##GETTER = v; return std::move(*this); } \
+	DecoderResult&& SETTER(TYPE&& v) && { _##GETTER = std::move(v); return std::move(*this); }
 
-	std::wstring ecLevel() const { return _ecLevel; }
-	void setEcLevel(const std::wstring& level) { _ecLevel = level; }
+	PROPERTY(int, numBits, setNumBits)
+	PROPERTY(std::list<ByteArray>, byteSegments, setByteSegments)
+	PROPERTY(std::wstring, ecLevel, setEcLevel)
+	PROPERTY(int, errorsCorrected, setErrorsCorrected)
+	PROPERTY(int, erasures, setErasures)
+	PROPERTY(int, structuredAppendParity, setStructuredAppendParity)
+	PROPERTY(int, structuredAppendSequenceNumber, setStructuredAppendSequenceNumber)
+	PROPERTY(std::shared_ptr<CustomData>, extra, setExtra)
 
-	int errorsCorrected() const { return _errorsCorrected; }
-	void setErrorsCorrected(int ec) { _errorsCorrected = ec; }
-
-	int erasures() const { return _erasures; }
-	void setErasures(int e) { _erasures = e; }
+#undef PROPERTY
 
 	bool hasStructuredAppend() const { return _structuredAppendParity >= 0 && _structuredAppendSequenceNumber >= 0; }
-
-	int structuredAppendParity() const { return _structuredAppendParity; }
-	void setStructuredAppendParity(int p) { _structuredAppendParity = p; }
-
-	int structuredAppendSequenceNumber() const { return _structuredAppendSequenceNumber; }
-	void setStructuredAppendSequenceNumber(int s) { _structuredAppendSequenceNumber = s; }
-
-	std::shared_ptr<CustomData> extra() const { return _extra; }
-	void setExtra(const std::shared_ptr<CustomData>& e) { _extra = e; }
 };
 
 } // ZXing

--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -64,8 +64,10 @@ public:
 	bool isValid() const { return StatusIsOK(_status); }
 	DecodeStatus errorCode() const { return _status; }
 
-	const ByteArray& rawBytes() const { return _rawBytes; }
-	const std::wstring& text() const { return _text; }
+	const ByteArray& rawBytes() const & { return _rawBytes; }
+	ByteArray&& rawBytes() && { return std::move(_rawBytes); }
+	const std::wstring& text() const & { return _text; }
+	std::wstring&& text() && { return std::move(_text); }
 
 	// Simple macro to set up getter/setter methods that save lots of boilerplate.
 	// It sets up a standard 'const & () const', 2 setters for setting lvalues via
@@ -75,7 +77,8 @@ public:
 	// return statement, e.g.
 	//    return DecoderResult(bytes, text).setEcLevel(level);
 #define PROPERTY(TYPE, GETTER, SETTER) \
-	const TYPE& GETTER() const { return _##GETTER; } \
+	const TYPE& GETTER() const & { return _##GETTER; } \
+	TYPE&& GETTER() && { return std::move(_##GETTER); } \
 	void SETTER(const TYPE& v) & { _##GETTER = v; } \
 	void SETTER(TYPE&& v) & { _##GETTER = std::move(v); } \
 	DecoderResult&& SETTER(const TYPE& v) && { _##GETTER = v; return std::move(*this); } \

--- a/core/src/DetectorResult.h
+++ b/core/src/DetectorResult.h
@@ -20,7 +20,6 @@
 #include "BitMatrix.h"
 
 #include <vector>
-#include <memory>
 
 namespace ZXing {
 
@@ -33,23 +32,25 @@ namespace ZXing {
 */
 class DetectorResult
 {
-	std::shared_ptr<const BitMatrix> _bits;
+	BitMatrix _bits;
 	std::vector<ResultPoint> _points;
+
+	DetectorResult(const DetectorResult&) = delete;
+	DetectorResult& operator=(const DetectorResult&) = delete;
 
 public:
 	DetectorResult() = default;
-	DetectorResult(const DetectorResult&) = delete;
-	DetectorResult& operator=(const DetectorResult&) = delete;
 	DetectorResult(DetectorResult&&) = default;
 	DetectorResult& operator=(DetectorResult&&) = default;
 
-	std::shared_ptr<const BitMatrix> bits() const { return _bits; }
-	void setBits(const std::shared_ptr<const BitMatrix>& bits) { _bits = bits; }
-	const std::vector<ResultPoint>& points() const { return _points; }
-	void setPoints(const std::vector<ResultPoint>& points) { _points = points; }
-	void setPoints(std::initializer_list<ResultPoint> list) { _points.assign(list); }
+	DetectorResult(BitMatrix&& bits, std::vector<ResultPoint>&& points)
+		: _bits(std::move(bits)), _points(std::move(points))
+	{}
 
-	bool isValid() const { return _bits && !_bits->empty(); }
+	const BitMatrix& bits() const { return _bits; }
+	const std::vector<ResultPoint>& points() const { return _points; }
+
+	bool isValid() const { return !_bits.empty(); }
 };
 
 } // ZXing

--- a/core/src/DetectorResult.h
+++ b/core/src/DetectorResult.h
@@ -17,13 +17,12 @@
 */
 
 #include "ResultPoint.h"
+#include "BitMatrix.h"
 
 #include <vector>
 #include <memory>
 
 namespace ZXing {
-
-class BitMatrix;
 
 /**
 * <p>Encapsulates the result of detecting a barcode in an image. This includes the raw
@@ -38,15 +37,19 @@ class DetectorResult
 	std::vector<ResultPoint> _points;
 
 public:
-	DetectorResult() {}
+	DetectorResult() = default;
 	DetectorResult(const DetectorResult&) = delete;
 	DetectorResult& operator=(const DetectorResult&) = delete;
+	DetectorResult(DetectorResult&&) = default;
+	DetectorResult& operator=(DetectorResult&&) = default;
 
 	std::shared_ptr<const BitMatrix> bits() const { return _bits; }
 	void setBits(const std::shared_ptr<const BitMatrix>& bits) { _bits = bits; }
 	const std::vector<ResultPoint>& points() const { return _points; }
 	void setPoints(const std::vector<ResultPoint>& points) { _points = points; }
 	void setPoints(std::initializer_list<ResultPoint> list) { _points.assign(list); }
+
+	bool isValid() const { return _bits && !_bits->empty(); }
 };
 
 } // ZXing

--- a/core/src/GlobalHistogramBinarizer.cpp
+++ b/core/src/GlobalHistogramBinarizer.cpp
@@ -117,7 +117,7 @@ static int EstimateBlackPoint(const std::array<int, LUMINANCE_BUCKETS>& buckets)
 }
 
 // Applies simple sharpening to the row data to improve performance of the 1D Readers.
-DecodeStatus
+bool
 GlobalHistogramBinarizer::getBlackRow(int y, BitArray& row) const
 {
 	int width = _source->width();
@@ -156,9 +156,9 @@ GlobalHistogramBinarizer::getBlackRow(int y, BitArray& row) const
 				center = right;
 			}
 		}
-		return DecodeStatus::NoError;
+		return true;
 	}
-	return DecodeStatus::NotFound;
+	return false;
 }
 
 static void InitBlackMatrix(const LuminanceSource& source, std::shared_ptr<const BitMatrix>& outMatrix)

--- a/core/src/GlobalHistogramBinarizer.h
+++ b/core/src/GlobalHistogramBinarizer.h
@@ -46,7 +46,7 @@ public:
 	bool isPureBarcode() const override;
 	int width() const override;
 	int height() const override;
-	DecodeStatus getBlackRow(int y, BitArray& row) const override;
+	bool getBlackRow(int y, BitArray& row) const override;
 	std::shared_ptr<const BitMatrix> getBlackMatrix() const override;
 	bool canCrop() const override;
 	std::shared_ptr<BinaryBitmap> cropped(int left, int top, int width, int height) const override;

--- a/core/src/GridSampler.cpp
+++ b/core/src/GridSampler.cpp
@@ -39,7 +39,7 @@ namespace {
 * @param points actual points in x1,y1,...,xn,yn form
 * @throws NotFoundException if an endpoint is lies outside the image boundaries
 */
-static DecodeStatus CheckAndNudgePoints(const BitMatrix& image, std::vector<float>& points)
+static bool CheckAndNudgePoints(const BitMatrix& image, std::vector<float>& points)
 {
 	int width = image.width();
 	int height = image.height();
@@ -49,7 +49,7 @@ static DecodeStatus CheckAndNudgePoints(const BitMatrix& image, std::vector<floa
 		int x = (int)points[offset];
 		int y = (int)points[offset + 1];
 		if (x < -1 || x > width || y < -1 || y > height) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 		nudged = false;
 		if (x == -1) {
@@ -75,7 +75,7 @@ static DecodeStatus CheckAndNudgePoints(const BitMatrix& image, std::vector<floa
 		int x = (int)points[offset];
 		int y = (int)points[offset + 1];
 		if (x < -1 || x > width || y < -1 || y > height) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 		nudged = false;
 		if (x == -1) {
@@ -95,7 +95,7 @@ static DecodeStatus CheckAndNudgePoints(const BitMatrix& image, std::vector<floa
 			nudged = true;
 		}
 	}
-	return DecodeStatus::NoError;
+	return true;
 }
 
 class DefaultGridSampler : public GridSampler
@@ -131,7 +131,8 @@ public:
 			transform.transformPoints(points.data(), max);
 			// Quick check to see if points transformed to something inside the image;
 			// sufficient to check the endpoints
-			CheckAndNudgePoints(image, points);
+			if (!CheckAndNudgePoints(image, points))
+				return {};
 			try {
 				for (int x = 0; x < max; x += 2) {
 					if (image.get(static_cast<int>(points[x]), static_cast<int>(points[x + 1]))) {

--- a/core/src/GridSampler.cpp
+++ b/core/src/GridSampler.cpp
@@ -102,24 +102,24 @@ class DefaultGridSampler : public GridSampler
 {
 public:
 
-	DecodeStatus sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY,
+	BitMatrix sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY,
 		float p1ToX, float p1ToY, float p2ToX, float p2ToY, float p3ToX, float p3ToY, float p4ToX, float p4ToY,
-		float p1FromX, float p1FromY, float p2FromX, float p2FromY, float p3FromX, float p3FromY, float p4FromX, float p4FromY,
-		BitMatrix& result) const override
+		float p1FromX, float p1FromY, float p2FromX, float p2FromY, float p3FromX, float p3FromY, float p4FromX,
+		float p4FromY) const override
 	{
 		auto transform = PerspectiveTransform::QuadrilateralToQuadrilateral(
 			p1ToX, p1ToY, p2ToX, p2ToY, p3ToX, p3ToY, p4ToX, p4ToY,
 			p1FromX, p1FromY, p2FromX, p2FromY, p3FromX, p3FromY, p4FromX, p4FromY);
 
-		return sampleGrid(image, dimensionX, dimensionY, transform, result);
+		return sampleGrid(image, dimensionX, dimensionY, transform);
 	}
 
-	DecodeStatus sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY, const PerspectiveTransform& transform, BitMatrix& result) const override
+	BitMatrix sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY, const PerspectiveTransform& transform) const override
 	{
-		if (dimensionX <= 0 || dimensionY <= 0) {
-			return DecodeStatus::NotFound;
-		}
-		result = BitMatrix(dimensionX, dimensionY);
+		if (dimensionX <= 0 || dimensionY <= 0)
+			return {};
+
+		BitMatrix result(dimensionX, dimensionY);
 		int max = 2 * dimensionX;
 		std::vector<float> points(max);
 		for (int y = 0; y < dimensionY; y++) {
@@ -148,10 +148,10 @@ public:
 				// This results in an ugly runtime exception despite our clever checks above -- can't have
 				// that. We could check each point's coordinates but that feels duplicative. We settle for
 				// catching and wrapping ArrayIndexOutOfBoundsException.
-				return DecodeStatus::NotFound;
+				return {};
 			}
 		}
-		return DecodeStatus::NoError;
+		return result;
 	}
 };
 

--- a/core/src/GridSampler.h
+++ b/core/src/GridSampler.h
@@ -22,7 +22,6 @@ namespace ZXing {
 
 class BitMatrix;
 class PerspectiveTransform;
-enum class DecodeStatus;
 
 /**
 * Implementations of this class can, given locations of finder patterns for a QR code in an

--- a/core/src/GridSampler.h
+++ b/core/src/GridSampler.h
@@ -71,12 +71,11 @@ public:
 	* @throws NotFoundException if image can't be sampled, for example, if the transformation defined
 	*   by the given points is invalid or results in sampling outside the image boundaries
 	*/
-	virtual DecodeStatus sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY,
+	virtual BitMatrix sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY,
 		float p1ToX, float p1ToY, float p2ToX, float p2ToY, float p3ToX, float p3ToY, float p4ToX, float p4ToY,
-		float p1FromX, float p1FromY, float p2FromX, float p2FromY, float p3FromX, float p3FromY, float p4FromX, float p4FromY,
-		BitMatrix& result) const = 0;
+		float p1FromX, float p1FromY, float p2FromX, float p2FromY, float p3FromX, float p3FromY, float p4FromX, float p4FromY) const = 0;
 
-	virtual DecodeStatus sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY, const PerspectiveTransform& transform, BitMatrix& result) const = 0;
+	virtual BitMatrix sampleGrid(const BitMatrix& image, int dimensionX, int dimensionY, const PerspectiveTransform& transform) const = 0;
 
 	static std::shared_ptr<GridSampler> Instance();
 	static void SetInstance(const std::shared_ptr<GridSampler>& inst);

--- a/core/src/ReedSolomonDecoder.cpp
+++ b/core/src/ReedSolomonDecoder.cpp
@@ -102,12 +102,12 @@ FindErrorLocations(const GenericGF& field, const GenericGFPoly& errorLocator, st
 	return DecodeStatus::NoError;
 }
 
-static void FindErrorMagnitudes(const GenericGF& field, const GenericGFPoly& errorEvaluator,
-                                const std::vector<int>& errorLocations, std::vector<int>& outMagnitudes)
+static std::vector<int>
+FindErrorMagnitudes(const GenericGF& field, const GenericGFPoly& errorEvaluator, const std::vector<int>& errorLocations)
 {
 	// This is directly applying Forney's Formula
 	size_t s = errorLocations.size();
-	outMagnitudes.resize(s);
+	std::vector<int> outMagnitudes(s);
 	for (size_t i = 0; i < s; ++i) {
 		int xiInverse = field.inverse(errorLocations[i]);
 		int denominator = 1;
@@ -127,6 +127,7 @@ static void FindErrorMagnitudes(const GenericGF& field, const GenericGFPoly& err
 			outMagnitudes[i] = field.multiply(outMagnitudes[i], xiInverse);
 		}
 	}
+	return outMagnitudes;
 }
 
 
@@ -153,12 +154,12 @@ ReedSolomonDecoder::decode(std::vector<int>& received, int twoS) const
 	if (StatusIsError(errStat)) {
 		return errStat;
 	}
-	std::vector<int> errorLocations, errorMagnitudes;
+	std::vector<int> errorLocations;
 	errStat = FindErrorLocations(*_field, sigma, errorLocations);
 	if (StatusIsError(errStat)) {
 		return errStat;
 	}
-	FindErrorMagnitudes(*_field, omega, errorLocations, errorMagnitudes);
+	auto errorMagnitudes = FindErrorMagnitudes(*_field, omega, errorLocations);
 
 	int receivedCount = static_cast<int>(received.size());
 	for (size_t i = 0; i < errorLocations.size(); ++i) {

--- a/core/src/ReedSolomonDecoder.h
+++ b/core/src/ReedSolomonDecoder.h
@@ -22,7 +22,6 @@
 namespace ZXing {
 
 class GenericGF;
-enum class DecodeStatus;
 
 /**
 * <p>Implements Reed-Solomon decoding, as the name implies.</p>

--- a/core/src/ReedSolomonDecoder.h
+++ b/core/src/ReedSolomonDecoder.h
@@ -49,8 +49,6 @@ enum class DecodeStatus;
 class ReedSolomonDecoder
 {
 public:
-	explicit ReedSolomonDecoder(const GenericGF& field) : _field(&field) {}
-
 	/**
 	* <p>Decodes given set of received codewords, which include both data and error-correction
 	* codewords. Really, this means it uses Reed-Solomon to detect and correct errors, in-place,
@@ -60,10 +58,7 @@ public:
 	* @param twoS number of error-correction codewords available
 	* @throws ReedSolomonException if decoding fails for any reason
 	*/
-	DecodeStatus decode(std::vector<int>& received, int twoS) const;
-
-private:
-	const GenericGF* _field;
+	static DecodeStatus Decode(const GenericGF& field, std::vector<int>& received, int twoS);
 };
 
 //class ReedSolomonException : public std::exception

--- a/core/src/ReedSolomonDecoder.h
+++ b/core/src/ReedSolomonDecoder.h
@@ -58,7 +58,7 @@ public:
 	* @param twoS number of error-correction codewords available
 	* @throws ReedSolomonException if decoding fails for any reason
 	*/
-	static DecodeStatus Decode(const GenericGF& field, std::vector<int>& received, int twoS);
+	static bool Decode(const GenericGF& field, std::vector<int>& received, int twoS);
 };
 
 //class ReedSolomonException : public std::exception

--- a/core/src/Result.cpp
+++ b/core/src/Result.cpp
@@ -22,9 +22,7 @@ namespace ZXing {
 void
 Result::addResultPoints(const std::vector<ResultPoint>& points)
 {
-	size_t oldSize = _resultPoints.size();
-	_resultPoints.resize(oldSize + points.size());
-	std::copy(points.begin(), points.end(), _resultPoints.begin() + oldSize);
+	_resultPoints.insert(resultPoints().end(), points.begin(), points.end());
 }
 
 } // ZXing

--- a/core/src/Result.cpp
+++ b/core/src/Result.cpp
@@ -19,32 +19,6 @@
 
 namespace ZXing {
 
-Result::Result(DecodeStatus status) :
-	_status(status)
-{
-}
-
-Result::Result(std::wstring text, ByteArray rawBytes, std::vector<ResultPoint> resultPoints, BarcodeFormat format, time_point tt) :
-	_status(DecodeStatus::NoError),
-	_text(std::move(text)),
-	_rawBytes(std::move(rawBytes)),
-	_resultPoints(std::move(resultPoints)),
-	_format(format),
-	_timestamp(tt)
-{
-}
-
-Result::Result(std::wstring text, ByteArray rawBytes, int numBits, std::vector<ResultPoint> resultPoints, BarcodeFormat format, time_point tt) :
-	_status(DecodeStatus::NoError),
-	_text(std::move(text)),
-	_rawBytes(std::move(rawBytes)),
-	_numBits(numBits),
-	_resultPoints(std::move(resultPoints)),
-	_format(format),
-	_timestamp(tt)
-{
-}
-
 void
 Result::addResultPoints(const std::vector<ResultPoint>& points)
 {

--- a/core/src/Result.h
+++ b/core/src/Result.h
@@ -43,19 +43,14 @@ public:
 
 	explicit Result(DecodeStatus status) : _status(status) {}
 
-	Result(std::wstring text, ByteArray rawBytes, int numBits, std::vector<ResultPoint> resultPoints,
-		   BarcodeFormat format)
-		: _text(std::move(text)),
+	Result(std::wstring&& text, ByteArray&& rawBytes, std::vector<ResultPoint>&& resultPoints, BarcodeFormat format)
+	    : _text(std::move(text)),
 	      _rawBytes(std::move(rawBytes)),
-	      _numBits(numBits),
 		  _resultPoints(std::move(resultPoints)),
 	      _format(format)
-	{}
-
-	Result(std::wstring text, ByteArray rawBytes, std::vector<ResultPoint> resultPoints, BarcodeFormat format)
-		: Result(std::move(text), std::move(rawBytes), static_cast<int>(rawBytes.size()) * 8, std::move(resultPoints),
-				 format)
-	{}
+	{
+		_numBits = static_cast<int>(_rawBytes.size()) * 8;
+	}
 
 	Result(DecoderResult&& decodeResult, std::vector<ResultPoint>&& resultPoints, BarcodeFormat format)
 		: _status(decodeResult.errorCode()),
@@ -95,6 +90,9 @@ public:
 	const std::wstring& text() const {
 		return _text;
 	}
+	void setText(std::wstring&& text) {
+		_text = std::move(text);
+	}
 
 	const ByteArray& rawBytes() const {
 		return _rawBytes;
@@ -108,14 +106,17 @@ public:
 		return _resultPoints;
 	}
 
-	void setResultPoints(const std::vector<ResultPoint>& points) {
-		_resultPoints = points;
+	void setResultPoints(std::vector<ResultPoint>&& points) {
+		_resultPoints = std::move(points);
 	}
 
 	void addResultPoints(const std::vector<ResultPoint>& points);
 
 	BarcodeFormat format() const {
 		return _format;
+	}
+	void setFormat(BarcodeFormat format) {
+		_format = format;
 	}
 
 	time_point timestamp() const {

--- a/core/src/Result.h
+++ b/core/src/Result.h
@@ -20,6 +20,7 @@
 #include "BarcodeFormat.h"
 #include "ResultPoint.h"
 #include "ResultMetadata.h"
+#include "DecoderResult.h"
 #include "DecodeStatus.h"
 
 #include <string>
@@ -40,9 +41,48 @@ class Result
 public:
 	using time_point = std::chrono::steady_clock::time_point;
 
-	explicit Result(DecodeStatus status);
-	Result(std::wstring text, ByteArray rawBytes, std::vector<ResultPoint> resultPoints, BarcodeFormat format, time_point tt = std::chrono::steady_clock::now());
-	Result(std::wstring text, ByteArray rawBytes, int numBits, std::vector<ResultPoint> resultPoints, BarcodeFormat format, time_point tt = std::chrono::steady_clock::now());
+	explicit Result(DecodeStatus status) : _status(status) {}
+
+	Result(std::wstring text, ByteArray rawBytes, int numBits, std::vector<ResultPoint> resultPoints,
+		   BarcodeFormat format)
+		: _text(std::move(text)),
+	      _rawBytes(std::move(rawBytes)),
+	      _numBits(numBits),
+		  _resultPoints(std::move(resultPoints)),
+	      _format(format)
+	{}
+
+	Result(std::wstring text, ByteArray rawBytes, std::vector<ResultPoint> resultPoints, BarcodeFormat format)
+		: Result(std::move(text), std::move(rawBytes), static_cast<int>(rawBytes.size()) * 8, std::move(resultPoints),
+				 format)
+	{}
+
+	Result(DecoderResult&& decodeResult, std::vector<ResultPoint>&& resultPoints, BarcodeFormat format)
+		: _status(decodeResult.errorCode()),
+	      _text(std::move(decodeResult).text()),
+		  _rawBytes(std::move(decodeResult).rawBytes()),
+	      _numBits(decodeResult.numBits()),
+		  _resultPoints(std::move(resultPoints)),
+	      _format(format)
+	{
+		if (!isValid())
+			return;
+
+		//TODO: change ResultMetadata::put interface, so we can move from decodeResult?
+		const auto& byteSegments = decodeResult.byteSegments();
+		if (!byteSegments.empty()) {
+			metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
+		}
+		const auto& ecLevel = decodeResult.ecLevel();
+		if (!ecLevel.empty()) {
+			metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
+		}
+		if (decodeResult.hasStructuredAppend()) {
+			metadata().put(ResultMetadata::STRUCTURED_APPEND_SEQUENCE, decodeResult.structuredAppendSequenceNumber());
+			metadata().put(ResultMetadata::STRUCTURED_APPEND_PARITY, decodeResult.structuredAppendParity());
+		}
+		//TODO: what about the other optional data in DecoderResult?
+	}
 
 	bool isValid() const {
 		return StatusIsOK(_status);
@@ -91,13 +131,13 @@ public:
 	}
 
 private:
-	DecodeStatus _status;
+	DecodeStatus _status = DecodeStatus::NoError;
 	std::wstring _text;
 	ByteArray _rawBytes;
 	int _numBits = 0;
 	std::vector<ResultPoint> _resultPoints;
 	BarcodeFormat _format = BarcodeFormat::FORMAT_COUNT;
-	time_point _timestamp;
+	time_point _timestamp = std::chrono::steady_clock::now();
 	ResultMetadata _metadata;
 };
 

--- a/core/src/WhiteRectDetector.cpp
+++ b/core/src/WhiteRectDetector.cpp
@@ -26,8 +26,7 @@ namespace ZXing {
 static const int INIT_SIZE = 10;
 static const int CORR = 1;
 
-DecodeStatus
-WhiteRectDetector::Detect(const BitMatrix& image, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3)
+bool WhiteRectDetector::Detect(const BitMatrix& image, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3)
 {
 	return Detect(image, INIT_SIZE, image.width() / 2, image.height() / 2, p0, p1, p2, p3);
 }
@@ -136,8 +135,7 @@ static void CenterEdges(const ResultPoint& y, const ResultPoint& z, const Result
 *         leftmost and the third, the rightmost
 * @throws NotFoundException if no Data Matrix Code can be found
 */
-DecodeStatus
-WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3)
+bool WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3)
 {
 	int height = image.height();
 	int width = image.width();
@@ -147,7 +145,7 @@ WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, Re
 	int up = y - halfsize;
 	int down = y + halfsize;
 	if (up < 0 || left < 0 || down >= height || right >= width) {
-		return DecodeStatus::NotFound;
+		return false;
 	}
 
 	bool sizeExceeded = false;
@@ -264,7 +262,7 @@ WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, Re
 		}
 
 		if (!found) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 
 		ResultPoint t;
@@ -275,7 +273,7 @@ WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, Re
 		}
 
 		if (!found) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 
 		ResultPoint x;
@@ -286,7 +284,7 @@ WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, Re
 		}
 
 		if (!found) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 
 		ResultPoint y;
@@ -297,14 +295,14 @@ WhiteRectDetector::Detect(const BitMatrix& image, int initSize, int x, int y, Re
 		}
 
 		if (!found) {
-			return DecodeStatus::NotFound;
+			return false;
 		}
 
 		CenterEdges(y, z, x, t, width, p0, p1, p2, p3);
-		return DecodeStatus::NoError;
+		return true;
 	}
 	else {
-		return DecodeStatus::NotFound;
+		return false;
 	}
 }
 

--- a/core/src/WhiteRectDetector.h
+++ b/core/src/WhiteRectDetector.h
@@ -18,7 +18,6 @@
 
 namespace ZXing {
 
-enum class DecodeStatus;
 class BitMatrix;
 class ResultPoint;
 

--- a/core/src/WhiteRectDetector.h
+++ b/core/src/WhiteRectDetector.h
@@ -53,8 +53,8 @@ public:
 	*         leftmost and the third, the rightmost
 	* @throws NotFoundException if no Data Matrix Code can be found
 	*/
-	static DecodeStatus Detect(const BitMatrix& image, int initSize, int x, int y, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3);
-	static DecodeStatus Detect(const BitMatrix& image, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3);
+	static bool Detect(const BitMatrix& image, int initSize, int x, int y, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3);
+	static bool Detect(const BitMatrix& image, ResultPoint& p0, ResultPoint& p1, ResultPoint& p2, ResultPoint& p3);
 };
 
 } // ZXing

--- a/core/src/ZXContainerAlgorithms.h
+++ b/core/src/ZXContainerAlgorithms.h
@@ -25,6 +25,11 @@ auto Find(const Container& c, const Value& v) -> decltype(std::begin(c)) {
     return std::find(std::begin(c), std::end(c), v);
 }
 
+template <typename Container, typename Predicate>
+auto FindIf(Container& c, Predicate p) -> decltype(std::begin(c)) {
+    return std::find_if(std::begin(c), std::end(c), p);
+}
+
 template <typename Container, typename Value>
 bool Contains(const Container& c, const Value& v) {
     return std::find(std::begin(c), std::end(c), v) != std::end(c);

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -179,9 +179,8 @@ static bool CorrectBits(const DetectorResult& ddata, const std::vector<bool>& ra
 		dataWords[i] = ReadCode(rawbits, offset, codewordSize);
 	}
 
-	if (StatusIsError(ReedSolomonDecoder::Decode(*gf, dataWords, numECCodewords))) {
+	if (!ReedSolomonDecoder::Decode(*gf, dataWords, numECCodewords))
 		return false;
-	}
 
 	// Now perform the unstuffing operation.
 	// First, count how many bits are going to be thrown out as stuffing

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -94,7 +94,7 @@ static std::vector<bool> ExtractBits(const DetectorResult& ddata)
 			alignmentMap[origCenter + i] = center + newOffset + 1;
 		}
 	}
-	auto matrix = ddata.bits();
+	auto& matrix = ddata.bits();
 	std::vector<bool> rawbits(TotalBitsInLayer(layers, compact));
 	for (int i = 0, rowOffset = 0; i < layers; i++) {
 		int rowSize = (layers - i) * 4 + (compact ? 9 : 12);
@@ -108,16 +108,16 @@ static std::vector<bool> ExtractBits(const DetectorResult& ddata)
 			for (int k = 0; k < 2; k++) {
 				// left column
 				rawbits[rowOffset + columnOffset + k] =
-					matrix->get(alignmentMap[low + k], alignmentMap[low + j]);
+					matrix.get(alignmentMap[low + k], alignmentMap[low + j]);
 				// bottom row
 				rawbits[rowOffset + 2 * rowSize + columnOffset + k] =
-					matrix->get(alignmentMap[low + j], alignmentMap[high - k]);
+					matrix.get(alignmentMap[low + j], alignmentMap[high - k]);
 				// right column
 				rawbits[rowOffset + 4 * rowSize + columnOffset + k] =
-					matrix->get(alignmentMap[high - k], alignmentMap[high - j]);
+					matrix.get(alignmentMap[high - k], alignmentMap[high - j]);
 				// top row
 				rawbits[rowOffset + 6 * rowSize + columnOffset + k] =
-					matrix->get(alignmentMap[high - j], alignmentMap[low + k]);
+					matrix.get(alignmentMap[high - j], alignmentMap[low + k]);
 			}
 		}
 		rowOffset += rowSize * 8;

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -355,16 +355,16 @@ static ByteArray ConvertBoolArrayToByteArray(const std::vector<bool>& boolArr)
 	return byteArr;
 }
 
-DecodeStatus
-Decoder::Decode(const DetectorResult& detectorResult, DecoderResult& result)
+DecoderResult Decoder::Decode(const DetectorResult& detectorResult)
 {
 	std::vector<bool> rawbits = ExtractBits(detectorResult);
 	std::vector<bool> correctedBits;
 	if (CorrectBits(detectorResult, rawbits, correctedBits)) {
+		DecoderResult result;
 		result.setText(TextDecoder::FromLatin1(GetEncodedData(correctedBits)));
 		result.setRawBytes(ConvertBoolArrayToByteArray(correctedBits));
 		result.setNumBits(static_cast<int>(correctedBits.size()));
-		return DecodeStatus::NoError;
+		return result;
 	}
 	else {
 		return DecodeStatus::FormatError;

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -360,11 +360,9 @@ DecoderResult Decoder::Decode(const DetectorResult& detectorResult)
 	std::vector<bool> rawbits = ExtractBits(detectorResult);
 	std::vector<bool> correctedBits;
 	if (CorrectBits(detectorResult, rawbits, correctedBits)) {
-		DecoderResult result;
-		result.setText(TextDecoder::FromLatin1(GetEncodedData(correctedBits)));
-		result.setRawBytes(ConvertBoolArrayToByteArray(correctedBits));
-		result.setNumBits(static_cast<int>(correctedBits.size()));
-		return result;
+		return DecoderResult(ConvertBoolArrayToByteArray(correctedBits),
+							 TextDecoder::FromLatin1(GetEncodedData(correctedBits)))
+		        .setNumBits(static_cast<int>(correctedBits.size()));
 	}
 	else {
 		return DecodeStatus::FormatError;

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -179,7 +179,7 @@ static bool CorrectBits(const DetectorResult& ddata, const std::vector<bool>& ra
 		dataWords[i] = ReadCode(rawbits, offset, codewordSize);
 	}
 
-	if (StatusIsError(ReedSolomonDecoder(*gf).decode(dataWords, numECCodewords))) {
+	if (StatusIsError(ReedSolomonDecoder::Decode(*gf, dataWords, numECCodewords))) {
 		return false;
 	}
 

--- a/core/src/aztec/AZDecoder.h
+++ b/core/src/aztec/AZDecoder.h
@@ -19,7 +19,6 @@
 namespace ZXing {
 
 class DecoderResult;
-enum class DecodeStatus;
 
 namespace Aztec {
 
@@ -34,7 +33,7 @@ class DetectorResult;
 class Decoder
 {
 public:
-	static DecodeStatus Decode(const DetectorResult& detectorResult, DecoderResult& result);
+	static DecoderResult Decode(const DetectorResult& detectorResult);
 };
 
 } // Aztec

--- a/core/src/aztec/AZDetector.cpp
+++ b/core/src/aztec/AZDetector.cpp
@@ -547,13 +547,7 @@ DetectorResult Detector::Detect(const BitMatrix& image, bool isMirror)
 	// 5. Get the corners of the matrix.
 	GetMatrixCornerPoints(bullsEyeCorners, compact, nbLayers, nbCenterLayers);
 
-	DetectorResult result;
-	result.setBits(std::make_shared<BitMatrix>(std::move(bits)));
-	result.setPoints({ bullsEyeCorners.begin(), bullsEyeCorners.end() });
-	result.setCompact(compact);
-	result.setNbDatablocks(nbDataBlocks);
-	result.setNbLayers(nbLayers);
-	return result;
+	return {std::move(bits), {bullsEyeCorners.begin(), bullsEyeCorners.end()}, compact, nbDataBlocks, nbLayers};
 }
 
 } // Aztec

--- a/core/src/aztec/AZDetector.cpp
+++ b/core/src/aztec/AZDetector.cpp
@@ -141,10 +141,9 @@ static bool GetCorrectedParameterData(int64_t parameterData, bool compact, int& 
 		parameterWords[i] = (int)parameterData & 0xF;
 		parameterData >>= 4;
 	}
-	DecodeStatus status = ReedSolomonDecoder::Decode(GenericGF::AztecParam(), parameterWords, numECCodewords);
-	if (StatusIsError(status)) {
+	if (!ReedSolomonDecoder::Decode(GenericGF::AztecParam(), parameterWords, numECCodewords))
 		return false;
-	}
+
 	// Toss the error correction.  Just return the data as an integer
 	result = 0;
 	for (int i = 0; i < numDataCodewords; i++) {

--- a/core/src/aztec/AZDetector.cpp
+++ b/core/src/aztec/AZDetector.cpp
@@ -430,8 +430,7 @@ static PixelPoint GetMatrixCenter(const BitMatrix& image)
 {
 	//Get a white rectangle that can be the border of the matrix in center bull's eye or
 	ResultPoint pointA, pointB, pointC, pointD;
-	DecodeStatus status = WhiteRectDetector::Detect(image, pointA, pointB, pointC, pointD);
-	if (StatusIsError(status)) {
+	if (!WhiteRectDetector::Detect(image, pointA, pointB, pointC, pointD)) {
 		// This exception can be in case the initial rectangle is white
 		// In that case, surely in the bull's eye, we try to expand the rectangle.
 		int cx = image.width() / 2;
@@ -449,8 +448,7 @@ static PixelPoint GetMatrixCenter(const BitMatrix& image)
 	// Redetermine the white rectangle starting from previously computed center.
 	// This will ensure that we end up with a white rectangle in center bull's eye
 	// in order to compute a more accurate center.
-	status = WhiteRectDetector::Detect(image, 15, cx, cy, pointA, pointB, pointC, pointD);
-	if (StatusIsError(status)) {
+	if (!WhiteRectDetector::Detect(image, 15, cx, cy, pointA, pointB, pointC, pointD)) {
 		// This exception can be in case the initial rectangle is white
 		// In that case we try to expand the rectangle.
 		pointA = GetFirstDifferent(image, { cx + 7, cy - 7 }, false, 1, -1).toResultPoint();

--- a/core/src/aztec/AZDetector.cpp
+++ b/core/src/aztec/AZDetector.cpp
@@ -141,7 +141,7 @@ static bool GetCorrectedParameterData(int64_t parameterData, bool compact, int& 
 		parameterWords[i] = (int)parameterData & 0xF;
 		parameterData >>= 4;
 	}
-	DecodeStatus status = ReedSolomonDecoder(GenericGF::AztecParam()).decode(parameterWords, numECCodewords);
+	DecodeStatus status = ReedSolomonDecoder::Decode(GenericGF::AztecParam(), parameterWords, numECCodewords);
 	if (StatusIsError(status)) {
 		return false;
 	}

--- a/core/src/aztec/AZDetector.h
+++ b/core/src/aztec/AZDetector.h
@@ -42,7 +42,7 @@ public:
 	* @return {@link AztecDetectorResult} encapsulating results of detecting an Aztec Code
 	* @throws NotFoundException if no Aztec Code can be found
 	*/
-	static DecodeStatus Detect(const BitMatrix& image, bool isMirror, DetectorResult& result);
+	static DetectorResult Detect(const BitMatrix& image, bool isMirror);
 };
 
 } // Aztec

--- a/core/src/aztec/AZDetector.h
+++ b/core/src/aztec/AZDetector.h
@@ -19,7 +19,6 @@
 namespace ZXing {
 
 class BitMatrix;
-enum class DecodeStatus;
 
 namespace Aztec {
 

--- a/core/src/aztec/AZDetectorResult.h
+++ b/core/src/aztec/AZDetectorResult.h
@@ -26,17 +26,22 @@ class DetectorResult : public ZXing::DetectorResult
 	int _nbDatablocks = 0;
 	int _nbLayers = 0;
 
+	DetectorResult(const DetectorResult&) = delete;
+	DetectorResult& operator=(const DetectorResult&) = delete;
+
 public:
-	DetectorResult() {}
+	DetectorResult() = default;
+	DetectorResult(DetectorResult&&) = default;
+	DetectorResult& operator=(DetectorResult&&) = default;
+
+	DetectorResult(BitMatrix&& bits, std::vector<ResultPoint>&& points, bool isCompact, int nbDatablocks, int nbLayers)
+		: ZXing::DetectorResult{std::move(bits), std::move(points)}, _compact(isCompact), _nbDatablocks(nbDatablocks),
+		  _nbLayers(nbLayers)
+	{}
 
 	bool isCompact() const { return _compact; }
-	void setCompact(bool compact) { _compact = compact; }
-
 	int nbDatablocks() const { return _nbDatablocks; }
-	void setNbDatablocks(int nb) { _nbDatablocks = nb; }
-
 	int nbLayers() const { return _nbLayers; }
-	void setNbLayers(int nb) { _nbLayers = nb; }
 };
 
 } // Aztec

--- a/core/src/aztec/AZReader.cpp
+++ b/core/src/aztec/AZReader.cpp
@@ -51,10 +51,6 @@ Reader::decode(const BinaryBitmap& image) const
 		}
 	}
 
-	if (!decodeResult.isValid()) {
-		return Result(decodeResult.errorCode());
-	}
-
 	//auto rpcb = hints.resultPointCallback();
 	//if (rpcb != nullptr) {
 	//	for (auto& p : points) {
@@ -62,16 +58,7 @@ Reader::decode(const BinaryBitmap& image) const
 	//	}
 	//}
 
-	Result result(decodeResult.text(), decodeResult.rawBytes(), decodeResult.numBits(), points, BarcodeFormat::AZTEC);
-	const auto& byteSegments = decodeResult.byteSegments();
-	if (!byteSegments.empty()) {
-		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
-	}
-	const auto& ecLevel = decodeResult.ecLevel();
-	if (!ecLevel.empty()) {
-		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
-	}
-	return result;
+	return Result(std::move(decodeResult), std::move(points), BarcodeFormat::AZTEC);
 }
 
 } // Aztec

--- a/core/src/aztec/AZReader.cpp
+++ b/core/src/aztec/AZReader.cpp
@@ -63,11 +63,11 @@ Reader::decode(const BinaryBitmap& image) const
 	//}
 
 	Result result(decodeResult.text(), decodeResult.rawBytes(), decodeResult.numBits(), points, BarcodeFormat::AZTEC);
-	auto& byteSegments = decodeResult.byteSegments();
+	const auto& byteSegments = decodeResult.byteSegments();
 	if (!byteSegments.empty()) {
 		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
 	}
-	auto ecLevel = decodeResult.ecLevel();
+	const auto& ecLevel = decodeResult.ecLevel();
 	if (!ecLevel.empty()) {
 		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
 	}

--- a/core/src/aztec/AZReader.cpp
+++ b/core/src/aztec/AZReader.cpp
@@ -36,19 +36,19 @@ Reader::decode(const BinaryBitmap& image) const
 		return Result(DecodeStatus::NotFound);
 	}
 
-	DetectorResult detectResult;
-	DecodeStatus status = Detector::Detect(*binImg, false, detectResult);
+	DetectorResult detectResult = Detector::Detect(*binImg, false);
 	DecoderResult decodeResult;
+	DecodeStatus status = DecodeStatus::NotFound;
 	std::vector<ResultPoint> points;
-	if (StatusIsOK(status)) {
+	if (detectResult.isValid()) {
 		points = detectResult.points();
 		status = Decoder::Decode(detectResult, decodeResult);
 	}
 	if (StatusIsError(status)) {
-		auto status2 = Detector::Detect(*binImg, true, detectResult);
-		if (StatusIsOK(status2)) {
+		detectResult = Detector::Detect(*binImg, true);
+		if (detectResult.isValid()) {
 			points = detectResult.points();
-			status2 = Decoder::Decode(detectResult, decodeResult);
+			auto status2 = Decoder::Decode(detectResult, decodeResult);
 			if (StatusIsError(status2)) {
 				return Result(status);
 			}

--- a/core/src/aztec/AZReader.cpp
+++ b/core/src/aztec/AZReader.cpp
@@ -37,25 +37,22 @@ Reader::decode(const BinaryBitmap& image) const
 	}
 
 	DetectorResult detectResult = Detector::Detect(*binImg, false);
-	DecoderResult decodeResult;
-	DecodeStatus status = DecodeStatus::NotFound;
+	DecoderResult decodeResult = DecodeStatus::NotFound;
 	std::vector<ResultPoint> points;
 	if (detectResult.isValid()) {
 		points = detectResult.points();
-		status = Decoder::Decode(detectResult, decodeResult);
+		decodeResult = Decoder::Decode(detectResult);
 	}
-	if (StatusIsError(status)) {
+	if (!decodeResult.isValid()) {
 		detectResult = Detector::Detect(*binImg, true);
 		if (detectResult.isValid()) {
 			points = detectResult.points();
-			auto status2 = Decoder::Decode(detectResult, decodeResult);
-			if (StatusIsError(status2)) {
-				return Result(status);
-			}
+			decodeResult = Decoder::Decode(detectResult);
 		}
-		else {
-			return Result(status);
-		}
+	}
+
+	if (!decodeResult.isValid()) {
+		return Result(decodeResult.errorCode());
 	}
 
 	//auto rpcb = hints.resultPointCallback();

--- a/core/src/aztec/AZReader.cpp
+++ b/core/src/aztec/AZReader.cpp
@@ -51,13 +51,6 @@ Reader::decode(const BinaryBitmap& image) const
 		}
 	}
 
-	//auto rpcb = hints.resultPointCallback();
-	//if (rpcb != nullptr) {
-	//	for (auto& p : points) {
-	//		rpcb(p.x(), p.y());
-	//	}
-	//}
-
 	return Result(std::move(decodeResult), std::move(points), BarcodeFormat::AZTEC);
 }
 

--- a/core/src/datamatrix/DMBitMatrixParser.cpp
+++ b/core/src/datamatrix/DMBitMatrixParser.cpp
@@ -348,18 +348,18 @@ public:
 * @return bytes encoded within the Data Matrix Code
 * @throws FormatException if the exact number of bytes expected is not read
 */
-DecodeStatus
-BitMatrixParser::ReadCodewords(const BitMatrix& bits, ByteArray& result)
+ByteArray
+BitMatrixParser::ReadCodewords(const BitMatrix& bits)
 {
 	const Version* version = ReadVersion(bits);
 	if (version == nullptr) {
-		return DecodeStatus::FormatError;
+		return {};
 	}
 
 	BitMatrix mappingBitMatrix = ExtractDataRegion(*version, bits);
 	BitMatrix readMappingMatrix(mappingBitMatrix.width(), mappingBitMatrix.height());
 
-	result.resize(version->totalCodewords());
+	ByteArray result(version->totalCodewords());
 	int resultOffset = 0;
 
 	int row = 4;
@@ -426,7 +426,10 @@ BitMatrixParser::ReadCodewords(const BitMatrix& bits, ByteArray& result)
 		}
 	} while ((row < numRows) || (column < numColumns));
 
-	return resultOffset == version->totalCodewords() ? DecodeStatus::NoError : DecodeStatus::FormatError;
+	if (resultOffset != version->totalCodewords())
+		return {};
+
+	return result;
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMBitMatrixParser.h
+++ b/core/src/datamatrix/DMBitMatrixParser.h
@@ -18,7 +18,6 @@
 
 namespace ZXing {
 
-enum class DecodeStatus;
 class BitMatrix;
 class ByteArray;
 

--- a/core/src/datamatrix/DMBitMatrixParser.h
+++ b/core/src/datamatrix/DMBitMatrixParser.h
@@ -29,7 +29,7 @@ class Version;
 class BitMatrixParser
 {
 public:
-	static DecodeStatus ReadCodewords(const BitMatrix& bits, ByteArray& result);
+	static ByteArray ReadCodewords(const BitMatrix& bits);
 	static const Version* ReadVersion(const BitMatrix& bits);
 };
 

--- a/core/src/datamatrix/DMDataBlock.cpp
+++ b/core/src/datamatrix/DMDataBlock.cpp
@@ -22,13 +22,12 @@
 namespace ZXing {
 namespace DataMatrix {
 
-DecodeStatus
-DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, std::vector<DataBlock>& result)
+std::vector<DataBlock> DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version)
 {
 	// First count the total number of data blocks
 	// Now establish DataBlocks of the appropriate size and number of data codewords
 	auto& ecBlocks = version.ecBlocks();
-	result.resize(ecBlocks.numBlocks());
+	std::vector<DataBlock> result(ecBlocks.numBlocks());
 	int numResultBlocks = 0;
 	for (auto& ecBlock : ecBlocks.blockArray()) {
 		for (int i = 0; i < ecBlock.count; i++) {
@@ -72,7 +71,10 @@ DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, 
 		}
 	}
 
-	return rawCodewordsOffset == rawCodewords.length() ? DecodeStatus::NoError : DecodeStatus::FormatError;
+	if (rawCodewordsOffset != rawCodewords.length())
+		return {};
+
+	return result;
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMDataBlock.h
+++ b/core/src/datamatrix/DMDataBlock.h
@@ -58,7 +58,7 @@ public:
 	* @return DataBlocks containing original bytes, "de-interleaved" from representation in the
 	*         Data Matrix Code
 	*/
-	static DecodeStatus GetDataBlocks(const ByteArray& rawCodewords, const Version& version, std::vector<DataBlock>& result);
+	static std::vector<DataBlock> GetDataBlocks(const ByteArray& rawCodewords, const Version& version);
 
 private:
 	int _numDataCodewords = 0;

--- a/core/src/datamatrix/DMDataBlock.h
+++ b/core/src/datamatrix/DMDataBlock.h
@@ -19,9 +19,6 @@
 #include "ByteArray.h"
 
 namespace ZXing {
-
-enum class DecodeStatus;
-
 namespace DataMatrix {
 
 class Version;

--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -489,7 +489,7 @@ static bool DecodeBase256Segment(BitSource& bits, std::string& result, std::list
 	return true;
 }
 
-static DecoderResult Decode(const ByteArray& bytes)
+static DecoderResult Decode(ByteArray&& bytes)
 {
 	BitSource bits(bytes);
 	std::string result;
@@ -533,11 +533,8 @@ static DecoderResult Decode(const ByteArray& bytes)
 	if (resultTrailer.length() > 0) {
 		result.append(resultTrailer);
 	}
-	DecoderResult decodeResult;
-	decodeResult.setRawBytes(bytes);
-	decodeResult.setText(TextDecoder::FromLatin1(result));
-	decodeResult.setByteSegments(byteSegments);
-	return decodeResult;
+
+	return DecoderResult(std::move(bytes), TextDecoder::FromLatin1(result)).setByteSegments(std::move(byteSegments));
 }
 
 } // namespace DecodedBitStreamParser
@@ -620,7 +617,7 @@ DecoderResult Decoder::Decode(const BitMatrix& bits)
 	}
 
 	// Decode the contents of that stream of bytes
-	return DecodedBitStreamParser::Decode(resultBytes);
+	return DecodedBitStreamParser::Decode(std::move(resultBytes));
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -568,16 +568,14 @@ CorrectErrors(ByteArray& codewordBytes, int numDataCodewords)
 	// First read into an array of ints
 	std::vector<int> codewordsInts(codewordBytes.begin(), codewordBytes.end());
 	int numECCodewords = codewordBytes.length() - numDataCodewords;
-	auto status = ReedSolomonDecoder::Decode(GenericGF::DataMatrixField256(), codewordsInts, numECCodewords);
-	if (StatusIsOK(status)) {
-		// Copy back into array of bytes -- only need to worry about the bytes that were data
-		// We don't care about errors in the error-correction codewords
-		std::copy_n(codewordsInts.begin(), numDataCodewords, codewordBytes.begin());
-	}
-	else if (StatusIsKindOf(status, DecodeStatus::ReedSolomonError)) {
+	if (!ReedSolomonDecoder::Decode(GenericGF::DataMatrixField256(), codewordsInts, numECCodewords))
 		return DecodeStatus::ChecksumError;
-	}
-	return status;
+
+	// Copy back into array of bytes -- only need to worry about the bytes that were data
+	// We don't care about errors in the error-correction codewords
+	std::copy_n(codewordsInts.begin(), numDataCodewords, codewordBytes.begin());
+
+	return DecodeStatus::NoError;
 }
 
 DecodeStatus

--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -568,7 +568,7 @@ CorrectErrors(ByteArray& codewordBytes, int numDataCodewords)
 	// First read into an array of ints
 	std::vector<int> codewordsInts(codewordBytes.begin(), codewordBytes.end());
 	int numECCodewords = codewordBytes.length() - numDataCodewords;
-	auto status = ReedSolomonDecoder(GenericGF::DataMatrixField256()).decode(codewordsInts, numECCodewords);
+	auto status = ReedSolomonDecoder::Decode(GenericGF::DataMatrixField256(), codewordsInts, numECCodewords);
 	if (StatusIsOK(status)) {
 		// Copy back into array of bytes -- only need to worry about the bytes that were data
 		// We don't care about errors in the error-correction codewords

--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -489,7 +489,7 @@ static bool DecodeBase256Segment(BitSource& bits, std::string& result, std::list
 	return true;
 }
 
-static DecodeStatus Decode(const ByteArray& bytes, DecoderResult& decodeResult)
+static DecoderResult Decode(const ByteArray& bytes)
 {
 	BitSource bits(bytes);
 	std::string result;
@@ -533,10 +533,11 @@ static DecodeStatus Decode(const ByteArray& bytes, DecoderResult& decodeResult)
 	if (resultTrailer.length() > 0) {
 		result.append(resultTrailer);
 	}
+	DecoderResult decodeResult;
 	decodeResult.setRawBytes(bytes);
 	decodeResult.setText(TextDecoder::FromLatin1(result));
 	decodeResult.setByteSegments(byteSegments);
-	return DecodeStatus::NoError;
+	return decodeResult;
 }
 
 } // namespace DecodedBitStreamParser
@@ -578,8 +579,7 @@ CorrectErrors(ByteArray& codewordBytes, int numDataCodewords)
 	return true;
 }
 
-DecodeStatus
-Decoder::Decode(const BitMatrix& bits, DecoderResult& result)
+DecoderResult Decoder::Decode(const BitMatrix& bits)
 {
 	// Construct a parser and read version, error-correction level
 	const Version* version = BitMatrixParser::ReadVersion(bits);
@@ -620,7 +620,7 @@ Decoder::Decode(const BitMatrix& bits, DecoderResult& result)
 	}
 
 	// Decode the contents of that stream of bytes
-	return DecodedBitStreamParser::Decode(resultBytes, result);
+	return DecodedBitStreamParser::Decode(resultBytes);
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMDecoder.h
+++ b/core/src/datamatrix/DMDecoder.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class DecoderResult;
 class BitMatrix;
-enum class DecodeStatus;
 
 namespace DataMatrix {
 
@@ -53,7 +52,7 @@ public:
 	* @throws FormatException if the Data Matrix Code cannot be decoded
 	* @throws ChecksumException if error correction fails
 	*/
-	static DecodeStatus Decode(const BitMatrix& bits, DecoderResult& result);
+	static DecoderResult Decode(const BitMatrix& bits);
 };
 
 } // DataMatrix

--- a/core/src/datamatrix/DMDetector.cpp
+++ b/core/src/datamatrix/DMDetector.cpp
@@ -292,8 +292,7 @@ static void OrderByBestPatterns(const ResultPoint*& p0, const ResultPoint*& p1, 
 static DetectorResult DetectOld(const BitMatrix& image)
 {
 	ResultPoint pointA, pointB, pointC, pointD;
-	DecodeStatus status = WhiteRectDetector::Detect(image, pointA, pointB, pointC, pointD);
-	if (StatusIsError(status)) {
+	if (!WhiteRectDetector::Detect(image, pointA, pointB, pointC, pointD)) {
 		return {};
 	}
 

--- a/core/src/datamatrix/DMDetector.cpp
+++ b/core/src/datamatrix/DMDetector.cpp
@@ -436,10 +436,7 @@ static DetectorResult DetectOld(const BitMatrix& image)
 	if (bits.empty())
 		return {};
 
-	DetectorResult result;
-	result.setBits(std::make_shared<BitMatrix>(std::move(bits)));
-	result.setPoints({ *topLeft, *bottomLeft, *bottomRight, correctedTopRight });
-	return result;
+	return {std::move(bits), {*topLeft, *bottomLeft, *bottomRight, correctedTopRight}};
 }
 
 /**
@@ -1050,11 +1047,7 @@ static DetectorResult DetectNew(const BitMatrix& image, bool tryRotate)
 			if (bits.empty())
 				continue;
 
-			DetectorResult result;
-			result.setBits(std::make_shared<BitMatrix>(std::move(bits)));
-			result.setPoints({tl, bl, br, tr});
-
-			return result;
+			return {std::move(bits), {tl, bl, br, tr}};
 		}
 		// reached border of image -> try next scan direction
 #ifndef PRINT_DEBUG

--- a/core/src/datamatrix/DMDetector.h
+++ b/core/src/datamatrix/DMDetector.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class BitMatrix;
 class DetectorResult;
-enum class DecodeStatus;
 
 namespace DataMatrix {
 

--- a/core/src/datamatrix/DMDetector.h
+++ b/core/src/datamatrix/DMDetector.h
@@ -39,7 +39,7 @@ public:
 	* @return {@link DetectorResult} encapsulating results of detecting a Data Matrix Code
 	* @throws NotFoundException if no Data Matrix Code can be found
 	*/
-	static DecodeStatus Detect(const BitMatrix& image, bool tryHarder, bool tryRotate, DetectorResult& result);
+	static DetectorResult Detect(const BitMatrix& image, bool tryHarder, bool tryRotate);
 };
 
 } // DataMatrix

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -128,11 +128,11 @@ Reader::decode(const BinaryBitmap& image) const
 	}
 
 	Result result(decoderResult.text(), decoderResult.rawBytes(), points, BarcodeFormat::DATA_MATRIX);
-	auto& byteSegments = decoderResult.byteSegments();
+	const auto& byteSegments = decoderResult.byteSegments();
 	if (!byteSegments.empty()) {
 		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
 	}
-	auto ecLevel = decoderResult.ecLevel();
+	const auto& ecLevel = decoderResult.ecLevel();
 	if (!ecLevel.empty()) {
 		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
 	}

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -116,12 +116,12 @@ Reader::decode(const BinaryBitmap& image) const
 		}
 	}
 	else {
-		DetectorResult detectorResult;
-		status = Detector::Detect(*binImg, _tryHarder, _tryRotate, detectorResult);
-		if (StatusIsOK(status)) {
-			status = Decoder::Decode(*detectorResult.bits(), decoderResult);
-			points = detectorResult.points();
-		}
+		DetectorResult detectorResult = Detector::Detect(*binImg, _tryHarder, _tryRotate);
+		if (!detectorResult.isValid())
+			return Result(DecodeStatus::NotFound);
+
+		status = Decoder::Decode(*detectorResult.bits(), decoderResult);
+		points = detectorResult.points();
 	}
 
 	if (StatusIsError(status)) {

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -107,25 +107,24 @@ Reader::decode(const BinaryBitmap& image) const
 
 	DecoderResult decoderResult;
 	std::vector<ResultPoint> points;
-	DecodeStatus status;
 	if (image.isPureBarcode()) {
 		BitMatrix bits = ExtractPureBits(*binImg);
 		if (bits.empty())
 			return Result(DecodeStatus::NotFound);
 
-		status = Decoder::Decode(bits, decoderResult);
+		decoderResult = Decoder::Decode(bits);
 	}
 	else {
 		DetectorResult detectorResult = Detector::Detect(*binImg, _tryHarder, _tryRotate);
 		if (!detectorResult.isValid())
 			return Result(DecodeStatus::NotFound);
 
-		status = Decoder::Decode(*detectorResult.bits(), decoderResult);
+		decoderResult = Decoder::Decode(*detectorResult.bits());
 		points = detectorResult.points();
 	}
 
-	if (StatusIsError(status)) {
-		return Result(status);
+	if (!decoderResult.isValid()) {
+		return Result(decoderResult.errorCode());
 	}
 
 	Result result(decoderResult.text(), decoderResult.rawBytes(), points, BarcodeFormat::DATA_MATRIX);

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -123,20 +123,7 @@ Reader::decode(const BinaryBitmap& image) const
 		points = detectorResult.points();
 	}
 
-	if (!decoderResult.isValid()) {
-		return Result(decoderResult.errorCode());
-	}
-
-	Result result(decoderResult.text(), decoderResult.rawBytes(), points, BarcodeFormat::DATA_MATRIX);
-	const auto& byteSegments = decoderResult.byteSegments();
-	if (!byteSegments.empty()) {
-		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
-	}
-	const auto& ecLevel = decoderResult.ecLevel();
-	if (!ecLevel.empty()) {
-		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
-	}
-	return result;
+	return Result(std::move(decoderResult), std::move(points), BarcodeFormat::DATA_MATRIX);
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -119,7 +119,7 @@ Reader::decode(const BinaryBitmap& image) const
 		if (!detectorResult.isValid())
 			return Result(DecodeStatus::NotFound);
 
-		decoderResult = Decoder::Decode(*detectorResult.bits());
+		decoderResult = Decoder::Decode(detectorResult.bits());
 		points = detectorResult.points();
 	}
 

--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -242,7 +242,7 @@ namespace DecodedBitStreamParser
 		return sb;
 	}
 
-	static DecoderResult Decode(const ByteArray& bytes, int mode)
+	static DecoderResult Decode(ByteArray&& bytes, int mode)
 	{
 		std::string result;
 		result.reserve(144);
@@ -268,11 +268,7 @@ namespace DecodedBitStreamParser
 				result.append(GetMessage(bytes, 1, 77));
 				break;
 		}
-		DecoderResult decodeResult;
-		decodeResult.setRawBytes(bytes);
-		decodeResult.setText(TextDecoder::FromLatin1(result));
-		decodeResult.setEcLevel(std::to_wstring(mode)); // really???
-		return decodeResult;
+		return DecoderResult(std::move(bytes), TextDecoder::FromLatin1(result)).setEcLevel(std::to_wstring(mode)); // really???
 	}
 
 
@@ -315,7 +311,7 @@ Decoder::Decode(const BitMatrix& bits)
 	std::copy_n(codewords.begin(), 10, datawords.begin());
 	std::copy_n(codewords.begin() + 20, datawords.size() - 10, datawords.begin() + 10);
 
-	return DecodedBitStreamParser::Decode(datawords, mode);
+	return DecodedBitStreamParser::Decode(std::move(datawords), mode);
 }
 
 } // MaxiCode

--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -52,7 +52,7 @@ static bool CorrectErrors(ByteArray& codewordBytes, int start, int dataCodewords
 		}
 	}
 
-	if (StatusIsOK(ReedSolomonDecoder(GenericGF::MaxiCodeField64()).decode(codewordsInts, ecCodewords / divisor))) {
+	if (StatusIsOK(ReedSolomonDecoder::Decode(GenericGF::MaxiCodeField64(), codewordsInts, ecCodewords / divisor))) {
 		// Copy back into array of bytes -- only need to worry about the bytes that were data
 		// We don't care about errors in the error-correction codewords
 		for (int i = 0; i < dataCodewords; i++) {

--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -242,7 +242,7 @@ namespace DecodedBitStreamParser
 		return sb;
 	}
 
-	static DecodeStatus Decode(const ByteArray& bytes, int mode, DecoderResult& decodeResult)
+	static DecoderResult Decode(const ByteArray& bytes, int mode)
 	{
 		std::string result;
 		result.reserve(144);
@@ -268,18 +268,19 @@ namespace DecodedBitStreamParser
 				result.append(GetMessage(bytes, 1, 77));
 				break;
 		}
+		DecoderResult decodeResult;
 		decodeResult.setRawBytes(bytes);
 		decodeResult.setText(TextDecoder::FromLatin1(result));
 		decodeResult.setEcLevel(std::to_wstring(mode)); // really???
-		return DecodeStatus::NoError;
+		return decodeResult;
 	}
 
 
 
 } // DecodedBitStreamParser
 
-DecodeStatus
-Decoder::Decode(const BitMatrix& bits, DecoderResult& result)
+DecoderResult
+Decoder::Decode(const BitMatrix& bits)
 {
 	ByteArray codewords = BitMatrixParser::ReadCodewords(bits);
 
@@ -314,7 +315,7 @@ Decoder::Decode(const BitMatrix& bits, DecoderResult& result)
 	std::copy_n(codewords.begin(), 10, datawords.begin());
 	std::copy_n(codewords.begin() + 20, datawords.size() - 10, datawords.begin() + 10);
 
-	return DecodedBitStreamParser::Decode(datawords, mode, result);
+	return DecodedBitStreamParser::Decode(datawords, mode);
 }
 
 } // MaxiCode

--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -52,17 +52,17 @@ static bool CorrectErrors(ByteArray& codewordBytes, int start, int dataCodewords
 		}
 	}
 
-	if (StatusIsOK(ReedSolomonDecoder::Decode(GenericGF::MaxiCodeField64(), codewordsInts, ecCodewords / divisor))) {
-		// Copy back into array of bytes -- only need to worry about the bytes that were data
-		// We don't care about errors in the error-correction codewords
-		for (int i = 0; i < dataCodewords; i++) {
-			if ((mode == ALL) || (i % 2 == (mode - 1))) {
-				codewordBytes[i + start] = static_cast<uint8_t>(codewordsInts[i / divisor]);
-			}
+	if (!ReedSolomonDecoder::Decode(GenericGF::MaxiCodeField64(), codewordsInts, ecCodewords / divisor))
+		return false;
+
+	// Copy back into array of bytes -- only need to worry about the bytes that were data
+	// We don't care about errors in the error-correction codewords
+	for (int i = 0; i < dataCodewords; i++) {
+		if ((mode == ALL) || (i % 2 == (mode - 1))) {
+			codewordBytes[i + start] = static_cast<uint8_t>(codewordsInts[i / divisor]);
 		}
-		return true;
 	}
-	return false;
+	return true;
 }
 
 /**

--- a/core/src/maxicode/MCDecoder.h
+++ b/core/src/maxicode/MCDecoder.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class DecoderResult;
 class BitMatrix;
-enum class DecodeStatus;
 
 namespace MaxiCode {
 
@@ -33,7 +32,7 @@ namespace MaxiCode {
 class Decoder
 {
 public:
-	static DecodeStatus Decode(const BitMatrix& bits, DecoderResult& result);
+	static DecoderResult Decode(const BitMatrix& bits);
 };
 
 } // MaxiCode

--- a/core/src/maxicode/MCReader.cpp
+++ b/core/src/maxicode/MCReader.cpp
@@ -37,25 +37,25 @@ namespace MaxiCode {
 * @see com.google.zxing.datamatrix.DataMatrixReader#extractPureBits(BitMatrix)
 * @see com.google.zxing.qrcode.QRCodeReader#extractPureBits(BitMatrix)
 */
-static bool ExtractPureBits(const BitMatrix& image, BitMatrix& bits)
+static BitMatrix ExtractPureBits(const BitMatrix& image)
 {
 	int left, top, width, height;
 	if (!image.getEnclosingRectangle(left, top, width, height)) {
-		return false;
+		return {};
 	}
 
 	// Now just read off the bits
-	bits = BitMatrix(BitMatrixParser::MATRIX_WIDTH, BitMatrixParser::MATRIX_HEIGHT);
+	BitMatrix result(BitMatrixParser::MATRIX_WIDTH, BitMatrixParser::MATRIX_HEIGHT);
 	for (int y = 0; y < BitMatrixParser::MATRIX_HEIGHT; y++) {
 		int iy = top + (y * height + height / 2) / BitMatrixParser::MATRIX_HEIGHT;
 		for (int x = 0; x < BitMatrixParser::MATRIX_WIDTH; x++) {
 			int ix = left + (x * width + width / 2 + (y & 0x01) *  width / 2) / BitMatrixParser::MATRIX_WIDTH;
 			if (image.get(ix, iy)) {
-				bits.set(x, y);
+				result.set(x, y);
 			}
 		}
 	}
-	return true;
+	return result;
 }
 
 Result
@@ -70,8 +70,8 @@ Reader::decode(const BinaryBitmap& image) const
 		return Result(DecodeStatus::NotFound);
 	}
 
-	BitMatrix bits;
-	if (!ExtractPureBits(*binImg, bits)) {
+	BitMatrix bits = ExtractPureBits(*binImg);
+	if (bits.empty()) {
 		return Result(DecodeStatus::NotFound);
 	}
 

--- a/core/src/maxicode/MCReader.cpp
+++ b/core/src/maxicode/MCReader.cpp
@@ -75,10 +75,9 @@ Reader::decode(const BinaryBitmap& image) const
 		return Result(DecodeStatus::NotFound);
 	}
 
-	DecoderResult decoderResult;
-	DecodeStatus status = Decoder::Decode(bits, decoderResult);
-	if (StatusIsError(status)) {
-		return Result(status);
+	DecoderResult decoderResult = Decoder::Decode(bits);
+	if (!decoderResult.isValid()) {
+		return Result(decoderResult.errorCode());
 	}
 	Result result(decoderResult.text(), decoderResult.rawBytes(), std::vector<ResultPoint>(), BarcodeFormat::MAXICODE);
 

--- a/core/src/maxicode/MCReader.cpp
+++ b/core/src/maxicode/MCReader.cpp
@@ -75,17 +75,7 @@ Reader::decode(const BinaryBitmap& image) const
 		return Result(DecodeStatus::NotFound);
 	}
 
-	DecoderResult decoderResult = Decoder::Decode(bits);
-	if (!decoderResult.isValid()) {
-		return Result(decoderResult.errorCode());
-	}
-	Result result(decoderResult.text(), decoderResult.rawBytes(), std::vector<ResultPoint>(), BarcodeFormat::MAXICODE);
-
-	const auto& ecLevel = decoderResult.ecLevel();
-	if (!ecLevel.empty()) {
-		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
-	}
-	return result;
+	return Result(Decoder::Decode(bits), {}, BarcodeFormat::MAXICODE);
 }
 
 } // MaxiCode

--- a/core/src/maxicode/MCReader.cpp
+++ b/core/src/maxicode/MCReader.cpp
@@ -81,7 +81,7 @@ Reader::decode(const BinaryBitmap& image) const
 	}
 	Result result(decoderResult.text(), decoderResult.rawBytes(), std::vector<ResultPoint>(), BarcodeFormat::MAXICODE);
 
-	auto ecLevel = decoderResult.ecLevel();
+	const auto& ecLevel = decoderResult.ecLevel();
 	if (!ecLevel.empty()) {
 		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
 	}

--- a/core/src/oned/ODCode128Reader.cpp
+++ b/core/src/oned/ODCode128Reader.cpp
@@ -399,7 +399,7 @@ Code128Reader::decodeRow(int rowNumber, const BitArray& row, std::unique_ptr<Dec
 
 	float right = (range.begin - row.begin()) + 0.5f * range.size();
 	float ypos = static_cast<float>(rowNumber);
-	return Result(TextDecoder::FromLatin1(result), rawCodes, { ResultPoint(left, ypos), ResultPoint(right, ypos) }, BarcodeFormat::CODE_128);
+	return Result(TextDecoder::FromLatin1(result), std::move(rawCodes), { ResultPoint(left, ypos), ResultPoint(right, ypos) }, BarcodeFormat::CODE_128);
 }
 
 } // OneD

--- a/core/src/oned/ODMultiUPCEANReader.cpp
+++ b/core/src/oned/ODMultiUPCEANReader.cpp
@@ -74,7 +74,7 @@ MultiUPCEANReader::decodeRow(int rowNumber, const BitArray& row, std::unique_ptr
 		Result result = reader->decodeRow(rowNumber, row, range);
 		if (!result.isValid())
 		{
-			if (StatusIsKindOf(result.status(), DecodeStatus::ReaderError))
+			if (StatusIsError(result.status()))
 				continue;
 			else
 				return result;

--- a/core/src/oned/ODMultiUPCEANReader.cpp
+++ b/core/src/oned/ODMultiUPCEANReader.cpp
@@ -96,10 +96,8 @@ MultiUPCEANReader::decodeRow(int rowNumber, const BitArray& row, std::unique_ptr
 		bool ean13MayBeUPCA = result.format() == BarcodeFormat::EAN_13 && !resultText.empty() && resultText[0] == '0';
 		bool canReturnUPCA = _formats.empty() || _formats.find(BarcodeFormat::UPC_A) != _formats.end();
 		if (ean13MayBeUPCA && canReturnUPCA) {
-			// Transfer the metdata across
-			Result resultUPCA(resultText.substr(1), result.rawBytes(), result.resultPoints(), BarcodeFormat::UPC_A);
-			resultUPCA.metadata().putAll(result.metadata());
-			return resultUPCA;
+			result.setText(resultText.substr(1));
+			result.setFormat(BarcodeFormat::UPC_A);
 		}
 		return result;
 	}

--- a/core/src/oned/ODRSS14Reader.cpp
+++ b/core/src/oned/ODRSS14Reader.cpp
@@ -343,16 +343,6 @@ DecodePair(const BitArray& row, bool right, int rowNumber)
 	auto range = FindFinderPattern(row, right, finderCounters);
 	auto pattern = ParseFoundFinderPattern(row, rowNumber, right, range, finderCounters);
 	if (pattern.isValid()) {
-		//PointCallback resultPointCallback = hints.resultPointCallback();
-		//if (resultPointCallback != nullptr) {
-		//	float center = 0.5f * static_cast<float>(patternStart + patternEnd);
-		//	if (right) {
-		//		// row is actually reversed
-		//		center = row.size() - 1 - center;
-		//	}
-		//	resultPointCallback(center, static_cast<float>(rowNumber));
-		//}
-
 		auto outside = DecodeDataCharacter(row, pattern, true);
 		if (outside.isValid()) {
 			auto inside = DecodeDataCharacter(row, pattern, false);

--- a/core/src/oned/ODReader.cpp
+++ b/core/src/oned/ODReader.cpp
@@ -152,12 +152,10 @@ DoDecode(const std::vector<std::unique_ptr<RowReader>>& readers, const BinaryBit
 						result.metadata().put(ResultMetadata::ORIENTATION, 180);
 						// And remember to flip the result points horizontally.
 						auto points = result.resultPoints();
-						if (!points.empty()) {
-							for (auto& p : points) {
-								p.set(width - p.x() - 1, p.y());
-							}
-							result.setResultPoints(points);
+						for (auto& p : points) {
+							p.set(width - p.x() - 1, p.y());
 						}
+						result.setResultPoints(std::move(points));
 					}
 					return result;
 				}
@@ -185,13 +183,11 @@ Reader::decode(const BinaryBitmap& image) const
 			metadata.put(ResultMetadata::ORIENTATION, (270 + metadata.getInt(ResultMetadata::ORIENTATION)) % 360);
 			// Update result points
 			auto points = result.resultPoints();
-			if (!points.empty()) {
-				int height = rotatedImage->height();
-				for (auto& p : points) {
-					p = ResultPoint(height - p.y() - 1, p.x());
-				}
-				result.setResultPoints(points);
+			int height = rotatedImage->height();
+			for (auto& p : points) {
+				p.set(height - p.y() - 1, p.x());
 			}
+			result.setResultPoints(std::move(points));
 		}
 	}
 	return result;

--- a/core/src/oned/ODReader.cpp
+++ b/core/src/oned/ODReader.cpp
@@ -141,12 +141,6 @@ DoDecode(const std::vector<std::unique_ptr<RowReader>>& readers, const BinaryBit
 			if (upsideDown) {
 				// reverse the row and continue
 				row.reverse();
-
-				// This means we will only ever draw result points *once* in the life of this method
-				// since we want to avoid drawing the wrong points after flipping the row, and,
-				// don't want to clutter with noise from every single row scan -- just the scans
-				// that start on the center line.
-				//currentHints.setResultPointCallback(nullptr);
 			}
 			// Look for a barcode
 			for (size_t r = 0; r < readers.size(); ++r) {

--- a/core/src/oned/ODReader.cpp
+++ b/core/src/oned/ODReader.cpp
@@ -130,8 +130,7 @@ DoDecode(const std::vector<std::unique_ptr<RowReader>>& readers, const BinaryBit
 		}
 
 		// Estimate black point for this row and load it:
-		auto status = image.getBlackRow(rowNumber, row);
-		if (StatusIsError(status)) {
+		if (!image.getBlackRow(rowNumber, row)) {
 			continue;
 		}
 

--- a/core/src/oned/ODUPCAReader.cpp
+++ b/core/src/oned/ODUPCAReader.cpp
@@ -21,11 +21,13 @@
 namespace ZXing {
 namespace OneD {
 
-static Result MaybeReturnResult(const Result& result)
+static Result MaybeReturnResult(Result&& result)
 {
 	const std::wstring& text = result.text();
 	if (!text.empty() && text[0] == '0') {
-		return Result(text.substr(1), ByteArray(), result.resultPoints(), BarcodeFormat::UPC_A);
+		result.setText(text.substr(1));
+		result.setFormat(BarcodeFormat::UPC_A);
+		return result;
 	}
 	else {
 		return Result(DecodeStatus::FormatError);

--- a/core/src/oned/ODUPCEANReader.cpp
+++ b/core/src/oned/ODUPCEANReader.cpp
@@ -120,28 +120,15 @@ UPCEANReader::decodeEnd(const BitArray& row, BitArray::Iterator begin) const
 Result
 UPCEANReader::decodeRow(int rowNumber, const BitArray& row, BitArray::Range startGuard) const
 {
-	//auto pointCallback = hints.resultPointCallback();
-	//if (pointCallback != nullptr) {
-	//	pointCallback(0.5f * (startGuardBegin + startGuardEnd), static_cast<float>(rowNumber));
-	//}
-
 	std::string result;
 	result.reserve(20);
 	auto range = decodeMiddle(row, startGuard.end, result);
 	if (!range)
 		return Result(DecodeStatus::NotFound);
 
-	/*if (pointCallback != nullptr) {
-		pointCallback(static_cast<float>(endStart), static_cast<float>(rowNumber));
-	}*/
-
 	auto stopGuard = decodeEnd(row, range.end);
 	if (!stopGuard)
 		return Result(DecodeStatus::NotFound);
-
-	/*if (pointCallback != nullptr) {
-		pointCallback(0.5f * (endRangeBegin + endRangeEnd), static_cast<float>(rowNumber));
-	}*/
 
 	// Make sure there is a quiet zone at least as big as the end pattern after the barcode. The
 	// spec might want more whitespace, but in practice this is the maximum we can count on.

--- a/core/src/pdf417/PDFDecodedBitStreamParser.cpp
+++ b/core/src/pdf417/PDFDecodedBitStreamParser.cpp
@@ -613,8 +613,8 @@ static DecodeStatus DecodeMacroBlock(const std::vector<int>& codewords, int code
 	return DecodeStatus::NoError;
 }
 
-DecodeStatus
-DecodedBitStreamParser::Decode(const std::vector<int>& codewords, int ecLevel, DecoderResult& result)
+DecoderResult
+DecodedBitStreamParser::Decode(const std::vector<int>& codewords, int ecLevel)
 {
 	std::wstring resultString;
 	auto encoding = DEFAULT_ENCODING;
@@ -680,16 +680,17 @@ DecodedBitStreamParser::Decode(const std::vector<int>& codewords, int ecLevel, D
 			status = DecodeStatus::FormatError;
 		}
 	}
-	if (resultString.empty()) {
-		status = DecodeStatus::FormatError;
-	}
+	if (resultString.empty())
+		return DecodeStatus::FormatError;
 
-	if (StatusIsOK(status)) {
-		result.setText(resultString);
-		result.setEcLevel(std::to_wstring(ecLevel));
-		result.setExtra(resultMetadata);
-	}
-	return status;
+	if (StatusIsError(status))
+		return status;
+
+	DecoderResult result;
+	result.setText(resultString);
+	result.setEcLevel(std::to_wstring(ecLevel));
+	result.setExtra(resultMetadata);
+	return result;
 }
 
 

--- a/core/src/pdf417/PDFDecodedBitStreamParser.cpp
+++ b/core/src/pdf417/PDFDecodedBitStreamParser.cpp
@@ -686,13 +686,10 @@ DecodedBitStreamParser::Decode(const std::vector<int>& codewords, int ecLevel)
 	if (StatusIsError(status))
 		return status;
 
-	DecoderResult result;
-	result.setText(resultString);
-	result.setEcLevel(std::to_wstring(ecLevel));
-	result.setExtra(resultMetadata);
-	return result;
+	return DecoderResult(ByteArray(), std::move(resultString))
+		.setEcLevel(std::to_wstring(ecLevel))
+		.setExtra(resultMetadata);
 }
-
 
 } // Pdf417
 } // ZXing

--- a/core/src/pdf417/PDFDecodedBitStreamParser.h
+++ b/core/src/pdf417/PDFDecodedBitStreamParser.h
@@ -20,7 +20,6 @@
 
 namespace ZXing {
 
-enum class DecodeStatus;
 class DecoderResult;
 
 namespace Pdf417 {
@@ -34,7 +33,7 @@ namespace Pdf417 {
 class DecodedBitStreamParser
 {
 public:
-	static DecodeStatus Decode(const std::vector<int>& codewords, int ecLevel, DecoderResult& result);
+	static DecoderResult Decode(const std::vector<int>& codewords, int ecLevel);
 };
 
 } // Pdf417

--- a/core/src/pdf417/PDFReader.cpp
+++ b/core/src/pdf417/PDFReader.cpp
@@ -70,9 +70,10 @@ DecodeStatus DoDecode(const BinaryBitmap& image, bool multiple, std::list<Result
 	}
 
 	for (const auto& points : detectorResult.points) {
-		DecoderResult decoderResult;
-		DecodeStatus status = ScanningDecoder::Decode(*detectorResult.bits, points[4], points[5], points[6], points[7], GetMinCodewordWidth(points), GetMaxCodewordWidth(points), decoderResult);
-		if (StatusIsOK(status)) {
+		DecoderResult decoderResult =
+			ScanningDecoder::Decode(*detectorResult.bits, points[4], points[5], points[6], points[7],
+									GetMinCodewordWidth(points), GetMaxCodewordWidth(points));
+		if (decoderResult.isValid()) {
 			std::vector<ResultPoint> foundPoints(points.size());
 			std::transform(points.begin(), points.end(), foundPoints.begin(), [](const Nullable<ResultPoint>& p) { return p.value(); });
 			Result result(decoderResult.text(), decoderResult.rawBytes(), foundPoints, BarcodeFormat::PDF_417);
@@ -86,7 +87,7 @@ DecodeStatus DoDecode(const BinaryBitmap& image, bool multiple, std::list<Result
 			}
 		}
 		else if (!multiple) {
-			return status;
+			return decoderResult.errorCode();
 		}
 	}
 	return results.empty() ? DecodeStatus::NotFound : DecodeStatus::NoError;

--- a/core/src/pdf417/PDFReader.cpp
+++ b/core/src/pdf417/PDFReader.cpp
@@ -76,8 +76,7 @@ DecodeStatus DoDecode(const BinaryBitmap& image, bool multiple, std::list<Result
 		if (decoderResult.isValid()) {
 			std::vector<ResultPoint> foundPoints(points.size());
 			std::transform(points.begin(), points.end(), foundPoints.begin(), [](const Nullable<ResultPoint>& p) { return p.value(); });
-			Result result(decoderResult.text(), decoderResult.rawBytes(), foundPoints, BarcodeFormat::PDF_417);
-			result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, decoderResult.ecLevel());
+			Result result(std::move(decoderResult), std::move(foundPoints), BarcodeFormat::PDF_417);
 			if (auto extra = decoderResult.extra()) {
 				result.metadata().put(ResultMetadata::PDF417_EXTRA_METADATA, extra);
 			}

--- a/core/src/pdf417/PDFScanningDecoder.h
+++ b/core/src/pdf417/PDFScanningDecoder.h
@@ -18,7 +18,6 @@
 
 namespace ZXing {
 
-enum class DecodeStatus;
 class BitMatrix;
 class ResultPoint;
 class DecoderResult;
@@ -32,10 +31,10 @@ namespace Pdf417 {
 class ScanningDecoder
 {
 public:
-	static DecodeStatus Decode(const BitMatrix& image,
+	static DecoderResult Decode(const BitMatrix& image,
 		const Nullable<ResultPoint>& imageTopLeft, const Nullable<ResultPoint>& imageBottomLeft,
 		const Nullable<ResultPoint>& imageTopRight, const Nullable<ResultPoint>& imageBottomRight,
-		int minCodewordWidth, int maxCodewordWidth, DecoderResult& result);
+		int minCodewordWidth, int maxCodewordWidth);
 };
 
 } // Pdf417

--- a/core/src/qrcode/QRAlignmentPattern.h
+++ b/core/src/qrcode/QRAlignmentPattern.h
@@ -39,6 +39,8 @@ public:
 		return _estimatedModuleSize;
 	}
 
+	bool isValid() const { return _estimatedModuleSize > 0.f; }
+
 	/**
 	* <p>Determines if this alignment pattern "about equals" an alignment pattern at the stated
 	* position and size -- meaning, it is at nearly the same center with nearly the same size.</p>

--- a/core/src/qrcode/QRAlignmentPatternFinder.cpp
+++ b/core/src/qrcode/QRAlignmentPatternFinder.cpp
@@ -128,7 +128,7 @@ static float CrossCheckVertical(const BitMatrix& image, int startI, int centerJ,
 * @return {@link AlignmentPattern} if we have found the same pattern twice, or null if not
 */
 static AlignmentPattern
-HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, float moduleSize, /*const PointCallback& pointCallback,*/ std::vector<AlignmentPattern>& possibleCenters)
+HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, float moduleSize, std::vector<AlignmentPattern>& possibleCenters)
 {
 	int stateCountTotal = Accumulate(stateCount, 0);
 	float centerJ = CenterFromEnd(stateCount, j);
@@ -143,16 +143,12 @@ HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i
 		}
 		// Hadn't found this before; save it
 		possibleCenters.emplace_back(centerJ, centerI, estimatedModuleSize);
-		/*if (pointCallback != nullptr) {
-			const ResultPoint& p = possibleCenters.back();
-			pointCallback(p.x(), p.y());
-		}*/
 	}
 	return {};
 }
 
 AlignmentPattern
-AlignmentPatternFinder::Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize /*, const PointCallback& pointCallback*/)
+AlignmentPatternFinder::Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize)
 {
 	int maxJ = startX + width;
 	int middleI = startY + (height / 2);
@@ -182,7 +178,7 @@ AlignmentPatternFinder::Find(const BitMatrix& image, int startX, int startY, int
 				else { // Counting white pixels
 					if (currentState == 2) { // A winner?
 						if (FoundPatternCross(stateCount, moduleSize)) { // Yes
-							auto result = HandlePossibleCenter(image, stateCount, i, j, moduleSize, /*pointCallback,*/ possibleCenters);
+							auto result = HandlePossibleCenter(image, stateCount, i, j, moduleSize, possibleCenters);
 							if (result.isValid())
 								return result;
 						}
@@ -205,7 +201,7 @@ AlignmentPatternFinder::Find(const BitMatrix& image, int startX, int startY, int
 			j++;
 		}
 		if (FoundPatternCross(stateCount, moduleSize)) {
-			auto result = HandlePossibleCenter(image, stateCount, i, maxJ, moduleSize, /*pointCallback,*/ possibleCenters);
+			auto result = HandlePossibleCenter(image, stateCount, i, maxJ, moduleSize, possibleCenters);
 			if (result.isValid())
 				return result;
 		}

--- a/core/src/qrcode/QRAlignmentPatternFinder.h
+++ b/core/src/qrcode/QRAlignmentPatternFinder.h
@@ -19,7 +19,6 @@
 namespace ZXing {
 
 class BitMatrix;
-//typedef std::function<void(float x, float y)> PointCallback;
 
 namespace QRCode {
 
@@ -55,7 +54,7 @@ public:
 	* @return {@link AlignmentPattern} if found
 	* @throws NotFoundException if not found
 	*/
-	static AlignmentPattern Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize /*, const PointCallback& pointCallback*/);
+	static AlignmentPattern Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize);
 
 };
 

--- a/core/src/qrcode/QRAlignmentPatternFinder.h
+++ b/core/src/qrcode/QRAlignmentPatternFinder.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class BitMatrix;
 //typedef std::function<void(float x, float y)> PointCallback;
-enum class DecodeStatus;
 
 namespace QRCode {
 

--- a/core/src/qrcode/QRAlignmentPatternFinder.h
+++ b/core/src/qrcode/QRAlignmentPatternFinder.h
@@ -56,7 +56,7 @@ public:
 	* @return {@link AlignmentPattern} if found
 	* @throws NotFoundException if not found
 	*/
-	static DecodeStatus Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize, /*const PointCallback& pointCallback,*/ AlignmentPattern &result);
+	static AlignmentPattern Find(const BitMatrix& image, int startX, int startY, int width, int height, float moduleSize /*, const PointCallback& pointCallback*/);
 
 };
 

--- a/core/src/qrcode/QRBitMatrixParser.cpp
+++ b/core/src/qrcode/QRBitMatrixParser.cpp
@@ -134,17 +134,17 @@ BitMatrixParser::ReadFormatInformation(const BitMatrix& bitMatrix, bool mirrored
 * @return bytes encoded within the QR Code
 * @throws FormatException if the exact number of bytes expected is not read
 */
-DecodeStatus
-BitMatrixParser::ReadCodewords(const BitMatrix& bitMatrix, const Version& version, ByteArray& result)
+ByteArray
+BitMatrixParser::ReadCodewords(const BitMatrix& bitMatrix, const Version& version)
 {
 	if (!hasValidDimension(bitMatrix))
-		return DecodeStatus::FormatError;
+		return {};
 
 	BitMatrix functionPattern;
 	version.buildFunctionPattern(functionPattern);
 
 	bool readingUp = true;
-	result.resize(version.totalCodewords());
+	ByteArray result(version.totalCodewords());
 	int resultOffset = 0;
 	int currentByte = 0;
 	int bitsRead = 0;
@@ -176,7 +176,10 @@ BitMatrixParser::ReadCodewords(const BitMatrix& bitMatrix, const Version& versio
 		}
 		readingUp ^= true; // readingUp = !readingUp; // switch directions
 	}
-	return resultOffset == version.totalCodewords() ? DecodeStatus::NoError : DecodeStatus::FormatError;
+	if (resultOffset != version.totalCodewords())
+		return {};
+
+	return result;
 }
 
 } // QRCode

--- a/core/src/qrcode/QRBitMatrixParser.h
+++ b/core/src/qrcode/QRBitMatrixParser.h
@@ -37,7 +37,8 @@ public:
 	* @param bitMatrix {@link BitMatrix} to parse
 	* return false if dimension is not >= 21 and 1 mod 4
 	*/
-	static DecodeStatus ParseVersionInfo(const BitMatrix& bitMatrix, bool mirrored, const Version*& parsedVersion, FormatInformation& parsedFormatInfo);
+	static const Version* ReadVersion(const BitMatrix& bitMatrix, bool mirrored);
+	static FormatInformation ReadFormatInformation(const BitMatrix& bitMatrix, bool mirrored);
 
 	/**
 	* <p>Reads the bits in the {@link BitMatrix} representing the finder pattern in the

--- a/core/src/qrcode/QRBitMatrixParser.h
+++ b/core/src/qrcode/QRBitMatrixParser.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class BitMatrix;
 class ByteArray;
-enum class DecodeStatus;
 
 namespace QRCode {
 

--- a/core/src/qrcode/QRBitMatrixParser.h
+++ b/core/src/qrcode/QRBitMatrixParser.h
@@ -48,7 +48,7 @@ public:
 	* @return bytes encoded within the QR Code
 	* or empty array if the exact number of bytes expected is not read
 	*/
-	static DecodeStatus ReadCodewords(const BitMatrix& bitMatrix, const Version& version, ByteArray& result);
+	static ByteArray ReadCodewords(const BitMatrix& bitMatrix, const Version& version);
 };
 
 } // QRCode

--- a/core/src/qrcode/QRDataBlock.cpp
+++ b/core/src/qrcode/QRDataBlock.cpp
@@ -25,12 +25,10 @@
 namespace ZXing {
 namespace QRCode {
 
-DecodeStatus
-DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, ErrorCorrectionLevel ecLevel, std::vector<DataBlock>& result)
+std::vector<DataBlock> DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, ErrorCorrectionLevel ecLevel)
 {
-	if (rawCodewords.length() != version.totalCodewords()) {
-		return DecodeStatus::FormatError;
-	}
+	if (rawCodewords.length() != version.totalCodewords())
+		return {};
 
 	// Figure out the number and size of data blocks used by this version and
 	// error correction level
@@ -39,7 +37,7 @@ DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, 
 	// First count the total number of data blocks
 	int totalBlocks = ecBlocks.numBlocks();
 
-	result.resize(totalBlocks);;
+	std::vector<DataBlock> result(totalBlocks);
 	// Now establish DataBlocks of the appropriate size and number of data codewords
 	int numResultBlocks = 0;
 	for (auto& ecBlock : ecBlocks.blockArray()) {
@@ -84,7 +82,7 @@ DataBlock::GetDataBlocks(const ByteArray& rawCodewords, const Version& version, 
 			result[j]._codewords[iOffset] = rawCodewords[rawCodewordsOffset++];
 		}
 	}
-	return DecodeStatus::NoError;
+	return result;
 }
 
 } // QRCode

--- a/core/src/qrcode/QRDataBlock.h
+++ b/core/src/qrcode/QRDataBlock.h
@@ -21,9 +21,6 @@
 #include <vector>
 
 namespace ZXing {
-
-enum class DecodeStatus;
-
 namespace QRCode {
 
 class Version;

--- a/core/src/qrcode/QRDataBlock.h
+++ b/core/src/qrcode/QRDataBlock.h
@@ -62,7 +62,7 @@ public:
 	* @return DataBlocks containing original bytes, "de-interleaved" from representation in the
 	*         QR Code
 	*/
-	static DecodeStatus GetDataBlocks(const ByteArray& rawCodewords, const Version& version, ErrorCorrectionLevel ecLevel, std::vector<DataBlock>& result);
+	static std::vector<DataBlock> GetDataBlocks(const ByteArray& rawCodewords, const Version& version, ErrorCorrectionLevel ecLevel);
 
 private:
 	int _numDataCodewords = 0;

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -305,7 +305,7 @@ ParseECIValue(BitSource& bits, int &outValue)
 * <p>See ISO 18004:2006, 6.4.3 - 6.4.7</p>
 */
 static DecoderResult
-DecodeBitStream(const ByteArray& bytes, const Version& version, ErrorCorrectionLevel ecLevel, const std::string& hintedCharset)
+DecodeBitStream(ByteArray&& bytes, const Version& version, ErrorCorrectionLevel ecLevel, const std::string& hintedCharset)
 {
 	BitSource bits(bytes);
 	std::wstring result;
@@ -404,17 +404,13 @@ DecodeBitStream(const ByteArray& bytes, const Version& version, ErrorCorrectionL
 		// from readBits() calls
 		return DecodeStatus::FormatError;
 	}
-	
-	DecoderResult decodeResult;
-	decodeResult.setRawBytes(bytes);
-	decodeResult.setText(result);
-	decodeResult.setByteSegments(byteSegments);
-	decodeResult.setEcLevel(ToString(ecLevel));
-	decodeResult.setStructuredAppendSequenceNumber(symbolSequence);
-	decodeResult.setStructuredAppendParity(parityData);
-	return decodeResult;
-}
 
+	return DecoderResult(std::move(bytes), std::move(result))
+		.setByteSegments(std::move(byteSegments))
+		.setEcLevel(ToString(ecLevel))
+		.setStructuredAppendParity(parityData)
+		.setStructuredAppendSequenceNumber(symbolSequence);
+}
 
 static DecoderResult
 DoDecode(const BitMatrix& bits, const Version& version, const FormatInformation& formatInfo, const std::string& hintedCharset)
@@ -452,7 +448,7 @@ DoDecode(const BitMatrix& bits, const Version& version, const FormatInformation&
 	}
 
 	// Decode the contents of that stream of bytes
-	return DecodeBitStream(resultBytes, version, ecLevel, hintedCharset);
+	return DecodeBitStream(std::move(resultBytes), version, ecLevel, hintedCharset);
 }
 
 static void

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -56,7 +56,7 @@ CorrectErrors(ByteArray& codewordBytes, int numDataCodewords)
 	std::vector<int> codewordsInts(codewordBytes.begin(), codewordBytes.end());
 
 	int numECCodewords = codewordBytes.length() - numDataCodewords;
-	auto status = ReedSolomonDecoder(GenericGF::QRCodeField256()).decode(codewordsInts, numECCodewords);
+	auto status = ReedSolomonDecoder::Decode(GenericGF::QRCodeField256(), codewordsInts, numECCodewords);
 	if (StatusIsOK(status))
 	{
 		// Copy back into array of bytes -- only need to worry about the bytes that were data

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -56,18 +56,13 @@ CorrectErrors(ByteArray& codewordBytes, int numDataCodewords)
 	std::vector<int> codewordsInts(codewordBytes.begin(), codewordBytes.end());
 
 	int numECCodewords = codewordBytes.length() - numDataCodewords;
-	auto status = ReedSolomonDecoder::Decode(GenericGF::QRCodeField256(), codewordsInts, numECCodewords);
-	if (StatusIsOK(status))
-	{
-		// Copy back into array of bytes -- only need to worry about the bytes that were data
-		// We don't care about errors in the error-correction codewords
-		std::copy_n(codewordsInts.begin(), numDataCodewords, codewordBytes.begin());
-	}
-	else if (StatusIsKindOf(status, DecodeStatus::ReedSolomonError))
-	{
-		status = DecodeStatus::ChecksumError;
-	}
-	return status;
+	if (!ReedSolomonDecoder::Decode(GenericGF::QRCodeField256(), codewordsInts, numECCodewords))
+		return DecodeStatus::ChecksumError;
+
+	// Copy back into array of bytes -- only need to worry about the bytes that were data
+	// We don't care about errors in the error-correction codewords
+	std::copy_n(codewordsInts.begin(), numDataCodewords, codewordBytes.begin());
+	return DecodeStatus::NoError;
 }
 
 

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -421,17 +421,15 @@ DoDecode(const BitMatrix& bits, const Version& version, const FormatInformation&
 	auto ecLevel = formatInfo.errorCorrectionLevel();
 
 	// Read codewords
-	ByteArray codewords;
-	DecodeStatus status = BitMatrixParser::ReadCodewords(bits, version, codewords);
-	if (StatusIsError(status)) {
-		return status;
-	}
+	ByteArray codewords = BitMatrixParser::ReadCodewords(bits, version);
+	if (codewords.empty())
+		return DecodeStatus::FormatError;
+
 	// Separate into data blocks
-	std::vector<DataBlock> dataBlocks;
-	status = DataBlock::GetDataBlocks(codewords, version, ecLevel, dataBlocks);
-	if (StatusIsError(status)) {
-		return status;
-	}
+	std::vector<DataBlock> dataBlocks = DataBlock::GetDataBlocks(codewords, version, ecLevel);
+	if (dataBlocks.empty())
+		return DecodeStatus::FormatError;
+
 	// Count total number of data bytes
 	int totalBytes = 0;
 	for (const auto& dataBlock : dataBlocks) {

--- a/core/src/qrcode/QRDecoder.h
+++ b/core/src/qrcode/QRDecoder.h
@@ -22,7 +22,6 @@ namespace ZXing {
 
 class DecoderResult;
 class BitMatrix;
-enum class DecodeStatus;
 
 namespace QRCode {
 
@@ -57,7 +56,7 @@ public:
 	* @throws FormatException if the QR Code cannot be decoded
 	* @throws ChecksumException if error correction fails
 	*/
-	static DecodeStatus Decode(const BitMatrix& bits, const std::string& hintedCharset, DecoderResult& result);
+	static DecoderResult Decode(const BitMatrix& bits, const std::string& hintedCharset);
 };
 
 } // QRCode

--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -338,10 +338,10 @@ Detector::Detect(const BitMatrix& image, bool pureBarcode, bool tryHarder, Detec
 {
 	/*PointCallback pointCallback = hints.resultPointCallback();*/
 
-	FinderPatternInfo info;
-	auto status = FinderPatternFinder::Find(image, /*pointCallback,*/ pureBarcode, tryHarder, info);
-	if (StatusIsError(status))
-		return status;
+	FinderPatternInfo info = FinderPatternFinder::Find(image, /*pointCallback,*/ pureBarcode, tryHarder);
+
+	if (!info.isValid())
+		return DecodeStatus::NotFound;
 	
 	return ProcessFinderPatternInfo(image, info, /*pointCallback,*/ result);
 }

--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -190,7 +190,7 @@ static float CalculateModuleSize(const BitMatrix& image, const ResultPoint& topL
 * @return {@link AlignmentPattern} if found, or null otherwise
 * @throws NotFoundException if an unexpected error occurs during detection
 */
-AlignmentPattern FindAlignmentInRegion(const BitMatrix& image, float overallEstModuleSize, int estAlignmentX, int estAlignmentY, float allowanceFactor /*, const PointCallback& pointCallback*/)
+AlignmentPattern FindAlignmentInRegion(const BitMatrix& image, float overallEstModuleSize, int estAlignmentX, int estAlignmentY, float allowanceFactor)
 {
 	// Look for an alignment pattern (3 modules in size) around where it
 	// should be
@@ -207,7 +207,7 @@ AlignmentPattern FindAlignmentInRegion(const BitMatrix& image, float overallEstM
 		return {};
 	}
 
-	return AlignmentPatternFinder::Find(image, alignmentAreaLeftX, alignmentAreaTopY, alignmentAreaRightX - alignmentAreaLeftX, alignmentAreaBottomY - alignmentAreaTopY, overallEstModuleSize /*, pointCallback*/);
+	return AlignmentPatternFinder::Find(image, alignmentAreaLeftX, alignmentAreaTopY, alignmentAreaRightX - alignmentAreaLeftX, alignmentAreaBottomY - alignmentAreaTopY, overallEstModuleSize);
 }
 
 static PerspectiveTransform CreateTransform(const ResultPoint& topLeft, const ResultPoint& topRight, const ResultPoint& bottomLeft, const AlignmentPattern& alignmentPattern, int dimension)
@@ -272,12 +272,8 @@ static int ComputeDimension(const ResultPoint& topLeft, const ResultPoint& topRi
 }
 
 static DetectorResult
-ProcessFinderPatternInfo(const BitMatrix& image, const FinderPatternInfo& info /*, const PointCallback& pointCallback*/)
+ProcessFinderPatternInfo(const BitMatrix& image, const FinderPatternInfo& info)
 {
-	//FinderPattern topLeft = info.getTopLeft();
-	//FinderPattern topRight = info.getTopRight();
-	//FinderPattern bottomLeft = info.getBottomLeft();
-
 	float moduleSize = CalculateModuleSize(image, info.topLeft, info.topRight, info.bottomLeft);
 	if (moduleSize < 1.0f) {
 		return {};
@@ -309,7 +305,7 @@ ProcessFinderPatternInfo(const BitMatrix& image, const FinderPatternInfo& info /
 
 		// Kind of arbitrary -- expand search radius before giving up
 		for (int i = 4; i <= 16; i <<= 1) {
-			alignmentPattern = FindAlignmentInRegion(image, moduleSize, estAlignmentX, estAlignmentY, static_cast<float>(i) /*, pointCallback*/);
+			alignmentPattern = FindAlignmentInRegion(image, moduleSize, estAlignmentX, estAlignmentY, static_cast<float>(i));
 			if (alignmentPattern.isValid())
 				break;
 		}
@@ -330,14 +326,12 @@ ProcessFinderPatternInfo(const BitMatrix& image, const FinderPatternInfo& info /
 
 DetectorResult Detector::Detect(const BitMatrix& image, bool pureBarcode, bool tryHarder)
 {
-	/*PointCallback pointCallback = hints.resultPointCallback();*/
-
-	FinderPatternInfo info = FinderPatternFinder::Find(image, /*pointCallback,*/ pureBarcode, tryHarder);
+	FinderPatternInfo info = FinderPatternFinder::Find(image, pureBarcode, tryHarder);
 
 	if (!info.isValid())
 		return {};
 	
-	return ProcessFinderPatternInfo(image, info /*pointCallback,*/);
+	return ProcessFinderPatternInfo(image, info);
 }
 
 } // QRCode

--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -322,15 +322,10 @@ ProcessFinderPatternInfo(const BitMatrix& image, const FinderPatternInfo& info /
 	if (bits.empty())
 		return {};
 
-	DetectorResult result;
-	result.setBits(std::make_shared<BitMatrix>(std::move(bits)));
-	if (!alignmentPattern.isValid()) {
-		result.setPoints({ info.bottomLeft, info.topLeft, info.topRight });
-	}
-	else {
-		result.setPoints({ info.bottomLeft, info.topLeft, info.topRight, alignmentPattern });
-	}
-	return result;
+	if (alignmentPattern.isValid())
+		return {std::move(bits), {info.bottomLeft, info.topLeft, info.topRight, alignmentPattern}};
+	else
+		return {std::move(bits), {info.bottomLeft, info.topLeft, info.topRight}};
 }
 
 DetectorResult Detector::Detect(const BitMatrix& image, bool pureBarcode, bool tryHarder)

--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -319,17 +319,15 @@ static DecodeStatus ProcessFinderPatternInfo(const BitMatrix& image, const Finde
 
 	PerspectiveTransform transform = CreateTransform(info.topLeft, info.topRight, info.bottomLeft, haveAlignPattern ? &alignmentPattern : nullptr, dimension);
 
-	auto bits = std::make_shared<BitMatrix>();
-	auto status = GridSampler::Instance()->sampleGrid(image, dimension, dimension, transform, *bits);
-	if (StatusIsError(status))
-		return status;
+	auto bits = GridSampler::Instance()->sampleGrid(image, dimension, dimension, transform);
+	if (bits.empty())
+		return DecodeStatus::NotFound;
 
+	result.setBits(std::make_shared<BitMatrix>(std::move(bits)));
 	if (!haveAlignPattern) {
-		result.setBits(bits);
 		result.setPoints({ info.bottomLeft, info.topLeft, info.topRight });
 	}
 	else {
-		result.setBits(bits);
 		result.setPoints({ info.bottomLeft, info.topLeft, info.topRight, alignmentPattern });
 	}
 	return DecodeStatus::NoError;

--- a/core/src/qrcode/QRDetector.h
+++ b/core/src/qrcode/QRDetector.h
@@ -20,7 +20,6 @@ namespace ZXing {
 
 class DetectorResult;
 class BitMatrix;
-enum class DecodeStatus;
 
 namespace QRCode {
 

--- a/core/src/qrcode/QRDetector.h
+++ b/core/src/qrcode/QRDetector.h
@@ -41,7 +41,7 @@ public:
 	* @throws NotFoundException if QR Code cannot be found
 	* @throws FormatException if a QR Code cannot be decoded
 	*/
-	static DecodeStatus Detect(const BitMatrix& image, bool pureBarcode, bool tryHarder, DetectorResult& result);
+	static DetectorResult Detect(const BitMatrix& image, bool pureBarcode, bool tryHarder);
 };
 
 } // QRCode

--- a/core/src/qrcode/QREncodeResult.h
+++ b/core/src/qrcode/QREncodeResult.h
@@ -33,7 +33,7 @@ namespace QRCode {
 class EncodeResult
 {
 public:
-	ErrorCorrectionLevel ecLevel = ErrorCorrectionLevel::Low;
+	ErrorCorrectionLevel ecLevel = ErrorCorrectionLevel::Invalid;
 	CodecMode::Mode mode = CodecMode::TERMINATOR;
 	const Version* version = nullptr;
 	int maskPattern = -1;

--- a/core/src/qrcode/QRErrorCorrectionLevel.cpp
+++ b/core/src/qrcode/QRErrorCorrectionLevel.cpp
@@ -17,12 +17,15 @@
 
 #include "qrcode/QRErrorCorrectionLevel.h"
 
+#include <cassert>
+
 namespace ZXing {
 namespace QRCode {
 
 const wchar_t* ToString(ErrorCorrectionLevel l)
 {
-	static const wchar_t* const LEVEL_STR[] = { L"L", L"M", L"Q", L"H" };
+	assert(l != ErrorCorrectionLevel::Invalid);
+	static const wchar_t* const LEVEL_STR[] = { L"L", L"M", L"Q", L"H", nullptr };
 	return LEVEL_STR[static_cast<int>(l)];
 }
 
@@ -34,7 +37,7 @@ ErrorCorrectionLevel FromString(const char* str)
 		case 'M': return ErrorCorrectionLevel::Medium;
 		case 'Q': return ErrorCorrectionLevel::Quality;
 		case 'H': return ErrorCorrectionLevel::High;
-		default: return ErrorCorrectionLevel::Medium;
+		default:  return ErrorCorrectionLevel::Invalid;
 	}
 }
 
@@ -46,7 +49,8 @@ ErrorCorrectionLevel ECLevelFromBits(int bits)
 
 int BitsFromECLevel(ErrorCorrectionLevel l)
 {
-	static const int BITS[] = { 1, 0, 3, 2 };
+	assert(l != ErrorCorrectionLevel::Invalid);
+	static const int BITS[] = { 1, 0, 3, 2, -1 };
 	return BITS[(int)l];
 }
 

--- a/core/src/qrcode/QRErrorCorrectionLevel.h
+++ b/core/src/qrcode/QRErrorCorrectionLevel.h
@@ -31,6 +31,7 @@ enum class ErrorCorrectionLevel
 	Medium,			// M = ~15% correction
 	Quality,		// Q = ~25% correction
 	High,			// H = ~30% correction
+	Invalid,		// denotes in invalid/unknown value
 };
 
 const wchar_t* ToString(ErrorCorrectionLevel l);

--- a/core/src/qrcode/QRFinderPattern.h
+++ b/core/src/qrcode/QRFinderPattern.h
@@ -45,6 +45,10 @@ public:
 		return _count;
 	}
 
+	bool isValid() const {
+		return _count > 0;
+	}
+
 	/**
 	* <p>Determines if this finder pattern "about equals" a finder pattern at the stated
 	* position and size -- meaning, it is at nearly the same center with nearly the same size.</p>

--- a/core/src/qrcode/QRFinderPatternFinder.cpp
+++ b/core/src/qrcode/QRFinderPatternFinder.cpp
@@ -470,7 +470,7 @@ static void OrderBestPatterns(std::vector<FinderPattern>& patterns)
 }
 
 
-FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder)
+FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, bool pureBarcode, bool tryHarder)
 {
 	int maxI = image.height();
 	int maxJ = image.width();
@@ -506,7 +506,7 @@ FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const Poin
 				if ((currentState & 1) == 0) { // Counting black pixels
 					if (currentState == 4) { // A winner?
 						if (FoundPatternCross(stateCount)) { // Yes
-							bool confirmed = HandlePossibleCenter(image, stateCount, i, j, pureBarcode, /*pointCallback,*/ possibleCenters);
+							bool confirmed = HandlePossibleCenter(image, stateCount, i, j, pureBarcode, possibleCenters);
 							if (confirmed) {
 								// Start examining every other line. Checking each line turned out to be too
 								// expensive and didn't improve performance.
@@ -562,7 +562,7 @@ FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const Poin
 			}
 		}
 		if (FinderPatternFinder::FoundPatternCross(stateCount)) {
-			bool confirmed = FinderPatternFinder::HandlePossibleCenter(image, stateCount, i, maxJ, pureBarcode, /*pointCallback,*/ possibleCenters);
+			bool confirmed = FinderPatternFinder::HandlePossibleCenter(image, stateCount, i, maxJ, pureBarcode, possibleCenters);
 			if (confirmed) {
 				iSkip = stateCount[0];
 				if (hasSkipped) {
@@ -623,7 +623,7 @@ FinderPatternFinder::FoundPatternCross(const StateCount& stateCount) {
 * @return true if a finder pattern candidate was found this time
 */
 bool
-FinderPatternFinder::HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, bool pureBarcode, /*const PointCallback& pointCallback,*/ std::vector<FinderPattern>& possibleCenters)
+FinderPatternFinder::HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, bool pureBarcode, std::vector<FinderPattern>& possibleCenters)
 {
 	int stateCountTotal = Accumulate(stateCount, 0);
 	float centerJ = CenterFromEnd(stateCount, j);

--- a/core/src/qrcode/QRFinderPatternFinder.cpp
+++ b/core/src/qrcode/QRFinderPatternFinder.cpp
@@ -451,37 +451,21 @@ static void OrderBestPatterns(std::vector<FinderPattern>& patterns)
 	float oneTwoDistance = ResultPoint::Distance(p1, p2);
 	float zeroTwoDistance = ResultPoint::Distance(p0, p2);
 
-	FinderPattern pointA;
-	FinderPattern pointB;
-	FinderPattern pointC;
 	// Assume one closest to other two is B; A and C will just be guesses at first
-	if (oneTwoDistance >= zeroOneDistance && oneTwoDistance >= zeroTwoDistance) {
-		pointB = p0;
-		pointA = p1;
-		pointC = p2;
-	}
-	else if (zeroTwoDistance >= oneTwoDistance && zeroTwoDistance >= zeroOneDistance) {
-		pointB = p1;
-		pointA = p0;
-		pointC = p2;
-	}
-	else {
-		pointB = p2;
-		pointA = p0;
-		pointC = p1;
-	}
+	if (oneTwoDistance >= zeroOneDistance && oneTwoDistance >= zeroTwoDistance)
+		std::swap(p0, p1);
+	else if (zeroTwoDistance >= oneTwoDistance && zeroTwoDistance >= zeroOneDistance)
+		; // do nothing, the order is correct
+	else
+		std::swap(p1, p2);
 
 	// Use cross product to figure out whether A and C are correct or flipped.
 	// This asks whether BC x BA has a positive z component, which is the arrangement
 	// we want for A, B, C. If it's negative, then we've got it flipped around and
 	// should swap A and C.
-	if (CrossProductZ(pointA, pointB, pointC) < 0.0f) {
-		std::swap(pointA, pointC);
+	if (CrossProductZ(p0, p1, p2) < 0.0f) {
+		std::swap(p0, p2);
 	}
-
-	p0 = pointA;
-	p1 = pointB;
-	p2 = pointC;
 }
 
 

--- a/core/src/qrcode/QRFinderPatternFinder.cpp
+++ b/core/src/qrcode/QRFinderPatternFinder.cpp
@@ -375,12 +375,12 @@ struct CenterComparator
 *         size differs from the average among those patterns the least
 * @throws NotFoundException if 3 such finder patterns do not exist
 */
-DecodeStatus SelectBestPatterns(std::vector<FinderPattern>& possibleCenters)
+static bool SelectBestPatterns(std::vector<FinderPattern>& possibleCenters)
 {
 	int startSize = static_cast<int>(possibleCenters.size());
 	if (startSize < 3) {
 		// Couldn't find enough finder patterns
-		return DecodeStatus::NotFound;
+		return false;
 	}
 
 	// Filter outlier possibilities whose module size is too different
@@ -423,7 +423,7 @@ DecodeStatus SelectBestPatterns(std::vector<FinderPattern>& possibleCenters)
 
 		possibleCenters.resize(3);
 	}
-	return DecodeStatus::NoError;
+	return true;
 }
 
 /**
@@ -592,9 +592,8 @@ FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const Poin
 		}
 	}
 
-	auto status = SelectBestPatterns(possibleCenters);
-	if (StatusIsError(status))
-		return status;
+	if (!SelectBestPatterns(possibleCenters))
+		return {};
 
 	OrderBestPatterns(possibleCenters);
 

--- a/core/src/qrcode/QRFinderPatternFinder.cpp
+++ b/core/src/qrcode/QRFinderPatternFinder.cpp
@@ -21,6 +21,7 @@
 #include "DecodeHints.h"
 #include "DecodeStatus.h"
 
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <limits>
@@ -439,8 +440,12 @@ static float CrossProductZ(const ResultPoint& a, const ResultPoint& b, const Res
 *
 * @param patterns array of three {@code ResultPoint} to order
 */
-static void OrderByBestPatterns(FinderPattern& p0, FinderPattern& p1, FinderPattern& p2)
+static void OrderBestPatterns(std::vector<FinderPattern>& patterns)
 {
+	assert(patterns.size() == 3);
+
+	auto &p0 = patterns[0], &p1 = patterns[1], &p2 = patterns[2];
+
 	// Find distances between pattern centers
 	float zeroOneDistance = ResultPoint::Distance(p0, p1);
 	float oneTwoDistance = ResultPoint::Distance(p1, p2);
@@ -591,7 +596,7 @@ FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const Poin
 	if (StatusIsError(status))
 		return status;
 
-	OrderByBestPatterns(possibleCenters[0], possibleCenters[1], possibleCenters[2]);
+	OrderBestPatterns(possibleCenters);
 
 	return {possibleCenters[0], possibleCenters[1], possibleCenters[2]};
 }

--- a/core/src/qrcode/QRFinderPatternFinder.cpp
+++ b/core/src/qrcode/QRFinderPatternFinder.cpp
@@ -480,8 +480,7 @@ static void OrderByBestPatterns(FinderPattern& p0, FinderPattern& p1, FinderPatt
 }
 
 
-DecodeStatus
-FinderPatternFinder::Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder, FinderPatternInfo& outInfo)
+FinderPatternInfo FinderPatternFinder::Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder)
 {
 	int maxI = image.height();
 	int maxJ = image.width();
@@ -594,11 +593,7 @@ FinderPatternFinder::Find(const BitMatrix& image, /*const PointCallback& pointCa
 
 	OrderByBestPatterns(possibleCenters[0], possibleCenters[1], possibleCenters[2]);
 
-	outInfo.bottomLeft = possibleCenters[0];
-	outInfo.topLeft = possibleCenters[1];
-	outInfo.topRight = possibleCenters[2];
-	
-	return DecodeStatus::NoError;
+	return {possibleCenters[0], possibleCenters[1], possibleCenters[2]};
 }
 
 

--- a/core/src/qrcode/QRFinderPatternFinder.h
+++ b/core/src/qrcode/QRFinderPatternFinder.h
@@ -43,7 +43,7 @@ class FinderPatternFinder
 public:
 	using StateCount = std::array<int, 5>;
 
-	static DecodeStatus Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder, FinderPatternInfo& outInfo);
+	static FinderPatternInfo Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder);
 
 	/**
 	* @param stateCount count of black/white/black/white/black pixels just read

--- a/core/src/qrcode/QRFinderPatternFinder.h
+++ b/core/src/qrcode/QRFinderPatternFinder.h
@@ -23,7 +23,6 @@ namespace ZXing {
 
 class BitMatrix;
 //typedef std::function<void(float x, float y)> PointCallback;
-enum class DecodeStatus;
 
 namespace QRCode {
 

--- a/core/src/qrcode/QRFinderPatternFinder.h
+++ b/core/src/qrcode/QRFinderPatternFinder.h
@@ -22,7 +22,6 @@
 namespace ZXing {
 
 class BitMatrix;
-//typedef std::function<void(float x, float y)> PointCallback;
 
 namespace QRCode {
 
@@ -42,7 +41,7 @@ class FinderPatternFinder
 public:
 	using StateCount = std::array<int, 5>;
 
-	static FinderPatternInfo Find(const BitMatrix& image, /*const PointCallback& pointCallback,*/ bool pureBarcode, bool tryHarder);
+	static FinderPatternInfo Find(const BitMatrix& image, bool pureBarcode, bool tryHarder);
 
 	/**
 	* @param stateCount count of black/white/black/white/black pixels just read
@@ -70,7 +69,7 @@ public:
 	* @param pureBarcode true if in "pure barcode" mode
 	* @return true if a finder pattern candidate was found this time
 	*/
-	static bool HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, bool pureBarcode, /*const PointCallback& pointCallback,*/ std::vector<FinderPattern>& possibleCenters);
+	static bool HandlePossibleCenter(const BitMatrix& image, const StateCount& stateCount, int i, int j, bool pureBarcode, std::vector<FinderPattern>& possibleCenters);
 };
 
 } // QRCode

--- a/core/src/qrcode/QRFinderPatternInfo.h
+++ b/core/src/qrcode/QRFinderPatternInfo.h
@@ -33,6 +33,8 @@ public:
 	FinderPattern bottomLeft;
 	FinderPattern topLeft;
 	FinderPattern topRight;
+
+	bool isValid() const { return bottomLeft.isValid() && topLeft.isValid() && topRight.isValid(); }
 };
 
 } // QRCode

--- a/core/src/qrcode/QRFormatInformation.h
+++ b/core/src/qrcode/QRFormatInformation.h
@@ -34,7 +34,9 @@ namespace QRCode {
 class FormatInformation
 {
 public:
-	bool decode(int maskedFormatInfo1, int maskedFormatInfo2);
+	FormatInformation() = default;
+
+	static FormatInformation DecodeFormatInformation(int maskedFormatInfo1, int maskedFormatInfo2);
 
 	ErrorCorrectionLevel errorCorrectionLevel() const {
 		return _errorCorrectionLevel;
@@ -44,12 +46,15 @@ public:
 		return _dataMask;
 	}
 
+	bool isValid() const { return _errorCorrectionLevel != ErrorCorrectionLevel::Invalid; }
+
 private:
-	ErrorCorrectionLevel _errorCorrectionLevel = ErrorCorrectionLevel::Medium;
+	ErrorCorrectionLevel _errorCorrectionLevel = ErrorCorrectionLevel::Invalid;
 	uint8_t _dataMask = 0;
 
-	void set(int formatInfo);
-	bool doDecode(int maskedFormatInfo1, int maskedFormatInfo2);
+	FormatInformation(int formatInfo);
+
+	static FormatInformation DoDecodeFormatInformation(int maskedFormatInfo1, int maskedFormatInfo2);
 };
 
 } // QRCode

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -192,20 +192,7 @@ Reader::decode(const BinaryBitmap& image) const
 	}
 #endif
 
-	Result result(decoderResult.text(), decoderResult.rawBytes(), points, BarcodeFormat::QR_CODE);
-	const auto& byteSegments = decoderResult.byteSegments();
-	if (!byteSegments.empty()) {
-		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
-	}
-	const auto& ecLevel = decoderResult.ecLevel();
-	if (!ecLevel.empty()) {
-		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
-	}
-	if (decoderResult.hasStructuredAppend()) {
-		result.metadata().put(ResultMetadata::STRUCTURED_APPEND_SEQUENCE, decoderResult.structuredAppendSequenceNumber());
-		result.metadata().put(ResultMetadata::STRUCTURED_APPEND_PARITY, decoderResult.structuredAppendParity());
-	}
-	return result;
+	return Result(std::move(decoderResult), std::move(points), BarcodeFormat::QR_CODE);
 }
 
 } // QRCode

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -171,7 +171,7 @@ Reader::decode(const BinaryBitmap& image) const
 		if (!detectorResult.isValid())
 			return Result(DecodeStatus::NotFound);
 
-		decoderResult = Decoder::Decode(*detectorResult.bits(), _charset);
+		decoderResult = Decoder::Decode(detectorResult.bits(), _charset);
 		points = detectorResult.points();
 	}
 

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -159,25 +159,24 @@ Reader::decode(const BinaryBitmap& image) const
 
 	DecoderResult decoderResult;
 	std::vector<ResultPoint> points;
-	DecodeStatus status;
 	if (image.isPureBarcode()) {
 		BitMatrix bits = ExtractPureBits(*binImg);
 		if (bits.empty())
 			return Result(DecodeStatus::NotFound);
 
-		status = Decoder::Decode(bits, _charset, decoderResult);
+		decoderResult = Decoder::Decode(bits, _charset);
 	}
 	else {
 		DetectorResult detectorResult = Detector::Detect(*binImg, image.isPureBarcode(), _tryHarder);
 		if (!detectorResult.isValid())
 			return Result(DecodeStatus::NotFound);
 
-		status = Decoder::Decode(*detectorResult.bits(), _charset, decoderResult);
+		decoderResult = Decoder::Decode(*detectorResult.bits(), _charset);
 		points = detectorResult.points();
 	}
 
-	if (StatusIsError(status)) {
-		return Result(status);
+	if (!decoderResult.isValid()) {
+		return Result(decoderResult.errorCode());
 	}
 
 	// If the code was mirrored: swap the bottom-left and the top-right points.

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -168,12 +168,12 @@ Reader::decode(const BinaryBitmap& image) const
 		status = Decoder::Decode(bits, _charset, decoderResult);
 	}
 	else {
-		DetectorResult detectorResult;
-		status = Detector::Detect(*binImg, image.isPureBarcode(), _tryHarder, detectorResult);
-		if (StatusIsOK(status)) {
-			status = Decoder::Decode(*detectorResult.bits(), _charset, decoderResult);
-			points = detectorResult.points();
-		}
+		DetectorResult detectorResult = Detector::Detect(*binImg, image.isPureBarcode(), _tryHarder);
+		if (!detectorResult.isValid())
+			return Result(DecodeStatus::NotFound);
+
+		status = Decoder::Decode(*detectorResult.bits(), _charset, decoderResult);
+		points = detectorResult.points();
 	}
 
 	if (StatusIsError(status)) {

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -193,11 +193,11 @@ Reader::decode(const BinaryBitmap& image) const
 #endif
 
 	Result result(decoderResult.text(), decoderResult.rawBytes(), points, BarcodeFormat::QR_CODE);
-	auto& byteSegments = decoderResult.byteSegments();
+	const auto& byteSegments = decoderResult.byteSegments();
 	if (!byteSegments.empty()) {
 		result.metadata().put(ResultMetadata::BYTE_SEGMENTS, byteSegments);
 	}
-	auto ecLevel = decoderResult.ecLevel();
+	const auto& ecLevel = decoderResult.ecLevel();
 	if (!ecLevel.empty()) {
 		result.metadata().put(ResultMetadata::ERROR_CORRECTION_LEVEL, ecLevel);
 	}


### PR DESCRIPTION
The major goal of these changes was to bring back the function call signatures closer to upstream and make them (arguably) more readable and natural by replacing the pattern
```
ResultType r;
auto status = SomeFunc(..., r);
if (StatusIsError(status))
    handleError();
```
with
```
ResultType r = SomeFunc(...);
if (!r.isValid())
    handleError();
```
Different strategies were used:
 * augment the ReslutType with a `bool isValid()` possible by the presence of an internal 'null state'
 * add a `DecoderState` member to ResultType (like already present in `ZXing::Result`)
 * switch to `bool` if only one error code was possible (like `NotFound`).

Also constructors for types transporting results (like `DecoderResult`, `Result`) were modified to support the most natural pattern
```
return ResultType(std::move(text), std::move(bytes), ...);
```
instead of
```
ResultType r;
r.setText(text);
r.setBytes(bytes);
...
return r;
```
Which also saves on memcopies and better shows that they are supposed to consume all the different pieces of result information and send it back to the caller.

Furthermore: all the ReedSolomonErrors turned out to be all mapped to the ChecksumError, so they have been removed, simplifying the code.

Those simplifications added up to 200+ lines of code removed.

Note: a little error counting during executing the test runner revealed the following numbers:
```
NotFound : 4.165.351
FormatError : 115.698
ChecksumError : 1.507
```
So, reporting 'NotFound' as an exception might really be a bad idea but using exceptions for reporting Format/Checksum errors might actually be not that bad.