### PR TITLE
Fix 3 different data matrix encoder bugs and improve code readability

### DIFF
--- a/core/src/datamatrix/DMDefaultPlacement.h
+++ b/core/src/datamatrix/DMDefaultPlacement.h
@@ -20,6 +20,7 @@
 namespace ZXing {
 
 class ByteMatrix;
+class ByteArray;
 
 namespace DataMatrix {
 
@@ -29,7 +30,7 @@ namespace DataMatrix {
 class DefaultPlacement
 {
 public:
-	static ByteMatrix Place(const std::vector<int>& codewords, int numcols, int numrows);
+	static ByteMatrix Place(const ByteArray& codewords, int numcols, int numrows);
 };
 
 } // DataMatrix

--- a/core/src/datamatrix/DMECEncoder.cpp
+++ b/core/src/datamatrix/DMECEncoder.cpp
@@ -17,55 +17,51 @@
 
 #include "datamatrix/DMECEncoder.h"
 #include "datamatrix/DMSymbolInfo.h"
+#include "ByteArray.h"
 #include "ZXStrConvWorkaround.h"
-#include "ZXContainerAlgorithms.h"
 
 #include <stdexcept>
 #include <string>
+#include <array>
+#include <algorithm>
 
 namespace ZXing {
 namespace DataMatrix {
 
 /**
-* Lookup table which factors to use for which number of error correction codewords.
-* See FACTORS.
-*/
-static const uint8_t FACTOR_SETS[] = { 5, 7, 10, 11, 12, 14, 18, 20, 24, 28, 36, 42, 48, 56, 62, 68 };
-
-/**
 * Precomputed polynomial factors for ECC 200.
 */
-static const uint8_t FACTORS[] = {
-	/*set  1*/ 228, 48, 15, 111, 62,
-	/*set  2*/ 23, 68, 144, 134, 240, 92, 254,
-	/*set  3*/ 28, 24, 185, 166, 223, 248, 116, 255, 110, 61,
-	/*set  4*/ 175, 138, 205, 12, 194, 168, 39, 245, 60, 97, 120,
-	/*set  5*/ 41, 153, 158, 91, 61, 42, 142, 213, 97, 178, 100, 242,
-	/*set  6*/ 156, 97, 192, 252, 95, 9, 157, 119, 138, 45, 18, 186, 83, 185,
-	/*set  7*/ 83, 195, 100, 39, 188, 75, 66, 61, 241, 213, 109, 129, 94, 254, 225, 48, 90, 188,
-	/*set  8*/ 15, 195, 244, 9, 233, 71, 168, 2, 188, 160, 153, 145, 253, 79, 108, 82, 27, 174, 186, 172,
-	/*set  9*/ 52, 190, 88, 205, 109, 39, 176, 21, 155, 197, 251, 223, 155, 21, 5, 172, 254, 124, 12, 181,
-				184, 96, 50, 193,
-	/*set 10*/ 211, 231, 43, 97, 71, 96, 103, 174, 37, 151, 170, 53, 75, 34, 249, 121, 17, 138, 110, 213,
-				141, 136, 120, 151, 233, 168, 93, 255,
-	/*set 11*/ 245, 127, 242, 218, 130, 250, 162, 181, 102, 120, 84, 179, 220, 251, 80, 182, 229, 18, 2, 4,
-				68, 33, 101, 137, 95, 119, 115, 44, 175, 184, 59, 25, 225, 98, 81, 112,
-	/*set 12*/ 77, 193, 137, 31, 19, 38, 22, 153, 247, 105, 122, 2, 245, 133, 242, 8, 175, 95, 100, 9, 167,
-				105, 214, 111, 57, 121, 21, 1, 253, 57, 54, 101, 248, 202, 69, 50, 150, 177, 226, 5, 9, 5,
-	/*set 13*/ 245, 132, 172, 223, 96, 32, 117, 22, 238, 133, 238, 231, 205, 188, 237, 87, 191, 106, 16, 147,
+static std::array<ByteArray, 16> FACTORS = {{
+	/*set  1*/ {228, 48, 15, 111, 62},
+	/*set  2*/ {23, 68, 144, 134, 240, 92, 254},
+	/*set  3*/ {28, 24, 185, 166, 223, 248, 116, 255, 110, 61},
+	/*set  4*/ {175, 138, 205, 12, 194, 168, 39, 245, 60, 97, 120},
+	/*set  5*/ {41, 153, 158, 91, 61, 42, 142, 213, 97, 178, 100, 242},
+	/*set  6*/ {156, 97, 192, 252, 95, 9, 157, 119, 138, 45, 18, 186, 83, 185},
+	/*set  7*/ {83, 195, 100, 39, 188, 75, 66, 61, 241, 213, 109, 129, 94, 254, 225, 48, 90, 188},
+	/*set  8*/ {15, 195, 244, 9, 233, 71, 168, 2, 188, 160, 153, 145, 253, 79, 108, 82, 27, 174, 186, 172},
+	/*set  9*/ {52, 190, 88, 205, 109, 39, 176, 21, 155, 197, 251, 223, 155, 21, 5, 172, 254, 124, 12, 181,
+				184, 96, 50, 193},
+	/*set 10*/ {211, 231, 43, 97, 71, 96, 103, 174, 37, 151, 170, 53, 75, 34, 249, 121, 17, 138, 110, 213,
+				141, 136, 120, 151, 233, 168, 93, 255},
+	/*set 11*/ {245, 127, 242, 218, 130, 250, 162, 181, 102, 120, 84, 179, 220, 251, 80, 182, 229, 18, 2, 4,
+				68, 33, 101, 137, 95, 119, 115, 44, 175, 184, 59, 25, 225, 98, 81, 112},
+	/*set 12*/ {77, 193, 137, 31, 19, 38, 22, 153, 247, 105, 122, 2, 245, 133, 242, 8, 175, 95, 100, 9, 167,
+				105, 214, 111, 57, 121, 21, 1, 253, 57, 54, 101, 248, 202, 69, 50, 150, 177, 226, 5, 9, 5},
+	/*set 13*/ {245, 132, 172, 223, 96, 32, 117, 22, 238, 133, 238, 231, 205, 188, 237, 87, 191, 106, 16, 147,
 				118, 23, 37, 90, 170, 205, 131, 88, 120, 100, 66, 138, 186, 240, 82, 44, 176, 87, 187, 147,
-				160, 175, 69, 213, 92, 253, 225, 19,
-	/*set 14*/ 175, 9, 223, 238, 12, 17, 220, 208, 100, 29, 175, 170, 230, 192, 215, 235, 150, 159, 36, 223,
+				160, 175, 69, 213, 92, 253, 225, 19},
+	/*set 14*/ {175, 9, 223, 238, 12, 17, 220, 208, 100, 29, 175, 170, 230, 192, 215, 235, 150, 159, 36, 223,
 				38, 200, 132, 54, 228, 146, 218, 234, 117, 203, 29, 232, 144, 238, 22, 150, 201, 117, 62, 207,
-				164, 13, 137, 245, 127, 67, 247, 28, 155, 43, 203, 107, 233, 53, 143, 46,
-	/*set 15*/ 242, 93, 169, 50, 144, 210, 39, 118, 202, 188, 201, 189, 143, 108, 196, 37, 185, 112, 134, 230,
+				164, 13, 137, 245, 127, 67, 247, 28, 155, 43, 203, 107, 233, 53, 143, 46},
+	/*set 15*/ {242, 93, 169, 50, 144, 210, 39, 118, 202, 188, 201, 189, 143, 108, 196, 37, 185, 112, 134, 230,
 				245, 63, 197, 190, 250, 106, 185, 221, 175, 64, 114, 71, 161, 44, 147, 6, 27, 218, 51, 63, 87,
-				10, 40, 130, 188, 17, 163, 31, 176, 170, 4, 107, 232, 7, 94, 166, 224, 124, 86, 47, 11, 204,
-	/*set 16*/ 220, 228, 173, 89, 251, 149, 159, 56, 89, 33, 147, 244, 154, 36, 73, 127, 213, 136, 248, 180,
+				10, 40, 130, 188, 17, 163, 31, 176, 170, 4, 107, 232, 7, 94, 166, 224, 124, 86, 47, 11, 204},
+	/*set 16*/ {220, 228, 173, 89, 251, 149, 159, 56, 89, 33, 147, 244, 154, 36, 73, 127, 213, 136, 248, 180,
 				234, 197, 158, 177, 68, 122, 93, 213, 15, 160, 227, 236, 66, 139, 153, 185, 202, 167, 179, 25,
 				220, 232, 96, 210, 231, 136, 223, 239, 181, 241, 59, 52, 172, 25, 49, 232, 211, 189, 64, 54,
-				108, 153, 132, 63, 96, 103, 82, 186,
-};
+                108, 153, 132, 63, 96, 103, 82, 186},
+}};
 
 static const uint8_t LOG[] = {
 	  0, 255,   1, 240,   2, 225, 241,  53,   3,  38, 226, 133, 242,  43,  54, 210,
@@ -105,38 +101,31 @@ static const uint8_t ALOG[] = {
 	  3,   6,  12,  24,  48,  96, 192, 173, 119, 238, 241, 207, 179,  75, 150,   1,
 };
 
-static void CreateECCBlock(std::vector<int>& codewords, size_t start, size_t len, int numECWords)
+static inline uint8_t mult(uint8_t a, uint8_t b)
 {
-	if (!Contains(FACTOR_SETS, numECWords)) {
-		throw std::invalid_argument("Illegal number of error correction codewords specified: " + std::to_string(numECWords));
-	}
-
-	int tableOffset = std::accumulate(std::begin(FACTOR_SETS), Find(FACTOR_SETS, numECWords), 0);
-	const uint8_t* poly = FACTORS + tableOffset;
-	std::vector<int> ecc(numECWords, 0);
-	for (size_t i = start; i < start + len; i++) {
-		int m = ecc[numECWords - 1] ^ codewords.at(i);
-		for (int k = numECWords - 1; k > 0; k--) {
-			if (m != 0 && poly[k] != 0) {
-				ecc[k] = (ecc[k - 1] ^ ALOG[(LOG[m] + LOG[poly[k]]) % 255]);
-			}
-			else {
-				ecc[k] = ecc[k - 1];
-			}
-		}
-		if (m != 0 && poly[0] != 0) {
-			ecc[0] = ALOG[(LOG[m] + LOG[poly[0]]) % 255];
-		}
-		else {
-			ecc[0] = 0;
-		}
-	}
-	codewords.insert(codewords.end(), ecc.rbegin(), ecc.rend());
+	if(a == 0 || b == 0)
+		return 0;
+	return ALOG[(LOG[a] + LOG[b]) % 255];
 }
 
-static void CreateECCBlock(std::vector<int>& codewords, int numECWords)
+static void CreateECCBlock(ByteArray& data, int codeOffset, int codeLength, int eccOffset, int eccLength, int stride)
 {
-	CreateECCBlock(codewords, 0, codewords.size(), numECWords);
+	// binary search for the poly vector with length numECWords
+	auto iter = std::lower_bound(FACTORS.begin(), FACTORS.end(), eccLength,
+							   [](const ByteArray& vec, size_t size) { return vec.size() < size; });
+	if (iter == FACTORS.end())
+		throw std::invalid_argument("Illegal number of error correction codewords specified: " + std::to_string(eccLength));
+
+	auto& poly = *iter;
+	ByteArray ecc(eccLength);
+	for (int i = 0; i < codeLength; ++i) {
+		const auto m = ecc.back() ^ data[codeOffset + i * stride];
+		for (size_t k = ecc.size() - 1; k > 0; k--)
+			ecc[k] = ecc[k - 1] ^ mult(m, poly[k]);
+		ecc[0] = mult(m, poly[0]);
+	}
+	for (int i = 0; i < eccLength; ++i)
+		data[eccOffset + i * stride] = ecc[eccLength - 1 - i];
 }
 
 /**
@@ -147,40 +136,20 @@ static void CreateECCBlock(std::vector<int>& codewords, int numECWords)
 * @return the codewords with interleaved error correction.
 */
 void
-ECEncoder::EncodeECC200(std::vector<int>& codewords, const SymbolInfo& symbolInfo)
+ECEncoder::EncodeECC200(ByteArray& codewords, const SymbolInfo& symbolInfo)
 {
-	int codewordCount = static_cast<int>(codewords.size());
-	if (codewordCount != symbolInfo.dataCapacity()) {
+	if (codewords.size() != symbolInfo.dataCapacity()) {
 		throw std::invalid_argument("The number of codewords does not match the selected symbol");
 	}
+	codewords.resize(symbolInfo.codewordCount(), 0);
 	int blockCount = symbolInfo.interleavedBlockCount();
 	if (blockCount == 1) {
-		codewords.reserve(codewordCount + symbolInfo.errorCodewords());
-		CreateECCBlock(codewords, symbolInfo.errorCodewords());
+		CreateECCBlock(codewords, 0, symbolInfo.dataCapacity(), symbolInfo.dataCapacity(), symbolInfo.errorCodewords(), 1);
 	}
 	else {
-		codewords.resize(codewordCount + symbolInfo.errorCodewords());
-		std::vector<int> dataSizes(blockCount);
-		std::vector<int> startPos(blockCount);
-		startPos[0] = 0;
-		for (int i = 0; i < blockCount; i++) {
-			dataSizes[i] = symbolInfo.dataLengthForInterleavedBlock(i + 1);
-			startPos[i] = startPos[i - 1] + dataSizes[i];
-		}
-		int errorSize = symbolInfo.errorLengthForInterleavedBlock();
-		std::vector<int> ecc;
-		for (int block = 0; block < blockCount; block++) {
-			ecc.clear();
-			ecc.reserve(dataSizes[block]);
-			for (int d = block; d < symbolInfo.dataCapacity(); d += blockCount) {
-				ecc.push_back(codewords.at(d));
-			}
-			CreateECCBlock(ecc, errorSize);
-			int pos = 0;
-			for (int e = block; e < errorSize * blockCount; e += blockCount) {
-				codewords.at(symbolInfo.dataCapacity() + e) = ecc.at(pos++);
-			}
-		}
+		for (int block = 0; block < blockCount; block++)
+			CreateECCBlock(codewords, block, symbolInfo.dataLengthForInterleavedBlock(block + 1),
+						   symbolInfo.dataCapacity() + block, symbolInfo.errorLengthForInterleavedBlock(), blockCount);
 	}
 }
 

--- a/core/src/datamatrix/DMECEncoder.h
+++ b/core/src/datamatrix/DMECEncoder.h
@@ -15,9 +15,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include <vector>
-
 namespace ZXing {
+
+class ByteArray;
+
 namespace DataMatrix {
 
 class SymbolInfo;
@@ -35,7 +36,7 @@ public:
 	* @param symbolInfo information about the symbol to be encoded
 	* @return the codewords with interleaved error correction.
 	*/
-	static void EncodeECC200(std::vector<int>& codewords, const SymbolInfo& symbolInfo);
+	static void EncodeECC200(ByteArray& codewords, const SymbolInfo& symbolInfo);
 };
 
 } // DataMatrix

--- a/core/src/datamatrix/DMHighLevelEncoder.cpp
+++ b/core/src/datamatrix/DMHighLevelEncoder.cpp
@@ -938,7 +938,7 @@ HighLevelEncoder::Encode(const std::wstring& msg, SymbolShape shape, int minWdit
 	auto symbolInfo = context.updateSymbolInfo(len);
 	int capacity = symbolInfo->dataCapacity();
 	if (len < capacity) {
-		if (encodingMode != ASCII_ENCODATION && encodingMode != BASE256_ENCODATION) {
+		if (encodingMode != ASCII_ENCODATION && encodingMode != BASE256_ENCODATION && encodingMode != EDIFACT_ENCODATION) {
 			context.addCodeword('\xfe'); //Unlatch (254)
 		}
 	}

--- a/core/src/datamatrix/DMHighLevelEncoder.cpp
+++ b/core/src/datamatrix/DMHighLevelEncoder.cpp
@@ -525,7 +525,8 @@ namespace C40Encoder {
 			if ((buffer.length() % 3) == 0) {
 				int newMode = LookAheadTest(context.message(), context.currentPos(), encodingMode);
 				if (newMode != encodingMode) {
-					context.setNewEncoding(newMode);
+					// Return to ASCII encodation, which will actually handle latch to new mode
+					context.setNewEncoding(ASCII_ENCODATION);
 					break;
 				}
 			}
@@ -667,7 +668,8 @@ namespace X12Encoder {
 
 				int newMode = LookAheadTest(context.message(), context.currentPos(), X12_ENCODATION);
 				if (newMode != X12_ENCODATION) {
-					context.setNewEncoding(newMode);
+					// Return to ASCII encodation, which will actually handle latch to new mode
+					context.setNewEncoding(ASCII_ENCODATION);
 					break;
 				}
 			}
@@ -797,6 +799,7 @@ namespace EdifactEncoder {
 
 				int newMode = LookAheadTest(context.message(), context.currentPos(), EDIFACT_ENCODATION);
 				if (newMode != EDIFACT_ENCODATION) {
+					// Return to ASCII encodation, which will actually handle latch to new mode
 					context.setNewEncoding(ASCII_ENCODATION);
 					break;
 				}
@@ -834,7 +837,8 @@ namespace Base256Encoder {
 
 			int newMode = LookAheadTest(context.message(), context.currentPos(), BASE256_ENCODATION);
 			if (newMode != BASE256_ENCODATION) {
-				context.setNewEncoding(newMode);
+				// Return to ASCII encodation, which will actually handle latch to new mode
+				context.setNewEncoding(ASCII_ENCODATION);
 				break;
 			}
 		}

--- a/core/src/datamatrix/DMWriter.cpp
+++ b/core/src/datamatrix/DMWriter.cpp
@@ -117,14 +117,14 @@ Writer::encode(const std::wstring& contents, int width, int height) const
 
 	//1. step: Data encodation
 	auto encoded = HighLevelEncoder::Encode(contents, _shapeHint, _minWidth, _minHeight, _maxWidth, _maxHeight);
-	std::vector<int> codewords(encoded.begin(), encoded.end());
-	const SymbolInfo* symbolInfo = SymbolInfo::Lookup(static_cast<int>(codewords.size()), _shapeHint, _minWidth, _minHeight, _maxWidth, _maxHeight);
+	const SymbolInfo* symbolInfo = SymbolInfo::Lookup(static_cast<int>(encoded.size()), _shapeHint, _minWidth, _minHeight, _maxWidth, _maxHeight);
 	if (symbolInfo == nullptr) {
-		throw std::invalid_argument("Can't find a symbol arrangement that matches the message. Data codewords: " + std::to_string(codewords.size()));
+		throw std::invalid_argument("Can't find a symbol arrangement that matches the message. Data codewords: " + std::to_string(encoded.size()));
 	}
 
 	//2. step: ECC generation
-	ECEncoder::EncodeECC200(codewords, *symbolInfo);
+	ECEncoder::EncodeECC200(encoded, *symbolInfo);
+	std::vector<int> codewords(encoded.begin(), encoded.end());
 
 	//3. step: Module placement in Matrix
 	ByteMatrix placement = DefaultPlacement::Place(codewords, symbolInfo->symbolDataWidth(), symbolInfo->symbolDataHeight());

--- a/core/src/datamatrix/DMWriter.cpp
+++ b/core/src/datamatrix/DMWriter.cpp
@@ -124,10 +124,9 @@ Writer::encode(const std::wstring& contents, int width, int height) const
 
 	//2. step: ECC generation
 	ECEncoder::EncodeECC200(encoded, *symbolInfo);
-	std::vector<int> codewords(encoded.begin(), encoded.end());
 
 	//3. step: Module placement in Matrix
-	ByteMatrix placement = DefaultPlacement::Place(codewords, symbolInfo->symbolDataWidth(), symbolInfo->symbolDataHeight());
+	ByteMatrix placement = DefaultPlacement::Place(encoded, symbolInfo->symbolDataWidth(), symbolInfo->symbolDataHeight());
 
 	//4. step: low-level encoding
 	return EncodeLowLevel(placement, *symbolInfo);

--- a/test/common/BitMatrixUtility.h
+++ b/test/common/BitMatrixUtility.h
@@ -8,8 +8,8 @@ class BitMatrix;
 
 namespace Utility {
     
-    void WriteBitMatrixAsPBM(const BitMatrix& matrix, std::ostream& out);
-	std::string ToString(const BitMatrix& matrix, char one, char zero, bool addSpace);
+    void WriteBitMatrixAsPBM(const BitMatrix& matrix, std::ostream& out, int quiteZone = 1);
+	std::string ToString(const BitMatrix& matrix, char one, char zero, bool addSpace, bool printAsCString = false);
 	std::string ToString(const BitMatrix& matrix);
 	BitMatrix ParseBitMatrix(const std::string& str, char one, bool expectSpace);
 	BitMatrix ParseBitMatrix(const std::string& str);

--- a/test/common/BitMatrixUtility.h
+++ b/test/common/BitMatrixUtility.h
@@ -9,6 +9,10 @@ class BitMatrix;
 namespace Utility {
     
     void WriteBitMatrixAsPBM(const BitMatrix& matrix, std::ostream& out, int quiteZone = 1);
+	inline void WriteBitMatrixAsPBM(const BitMatrix& matrix, std::ostream&& out, int quiteZone = 1)
+	{
+		WriteBitMatrixAsPBM(matrix, out, quiteZone);
+	}
 	std::string ToString(const BitMatrix& matrix, char one, char zero, bool addSpace, bool printAsCString = false);
 	std::string ToString(const BitMatrix& matrix);
 	BitMatrix ParseBitMatrix(const std::string& str, char one, bool expectSpace);

--- a/test/common/ByteMatrixUtility.cpp
+++ b/test/common/ByteMatrixUtility.cpp
@@ -29,9 +29,8 @@ std::string ToString(const ByteMatrix& matrix, char one, char zero, char other, 
 {
 	std::string result;
 	result.reserve((addSpace ? 2 : 1) * (matrix.width() * matrix.height()) + matrix.height());
-	int width = matrix.width();
 	for (int y = 0; y < matrix.height(); ++y) {
-		for (int x = 0; x < width; ++x) {
+		for (int x = 0; x < matrix.width(); ++x) {
 			auto c = matrix.get(x, y);
 			if (c == 1)
 				result.push_back(one);
@@ -39,9 +38,8 @@ std::string ToString(const ByteMatrix& matrix, char one, char zero, char other, 
 				result.push_back(zero);
 			else
 				result.push_back(other);
-			if (addSpace) {
+			if (addSpace)
 				result.push_back(' ');
-			}
 		}
 		result.push_back('\n');
 	}

--- a/test/runners/generic/TestReaderMain.cpp
+++ b/test/runners/generic/TestReaderMain.cpp
@@ -285,7 +285,7 @@ int main(int argc, char** argv)
 	pathPrefix = argv[1];
 	bool isPure = getenv("IS_PURE");
 
-	if (pathPrefix.extension() == ".png" || pathPrefix.extension() == ".jpg" || pathPrefix.extension() == ".pgm") {
+	if ( Contains(std::vector<std::string>{".png", ".jpg", ".pgm", ".gif"}, pathPrefix.extension()) ) {
 #if 0
 		TestReader reader(false, false, "QR_CODE");
 #else

--- a/test/runners/generic/TestReaderMain.cpp
+++ b/test/runners/generic/TestReaderMain.cpp
@@ -108,11 +108,11 @@ public:
 		_reader = std::make_shared<MultiFormatReader>(hints);
 	}
 
-	Result read(const fs::path& filename, int rotation = 0)
+	Result read(const fs::path& filename, int rotation = 0, bool isPure = false)
 	{
 		auto& binImg = _cache[filename];
 		if (!binImg)
-			binImg = std::make_shared<Binarizer>(readImage(filename));
+			binImg = std::make_shared<Binarizer>(readImage(filename), isPure);
 		auto result = _reader->read(*binImg->rotated(rotation));
 		if (result.isValid()) {
 			std::string text;
@@ -283,6 +283,7 @@ int main(int argc, char** argv)
 	}
 
 	pathPrefix = argv[1];
+	bool isPure = getenv("IS_PURE");
 
 	if (pathPrefix.extension() == ".png" || pathPrefix.extension() == ".jpg" || pathPrefix.extension() == ".pgm") {
 #if 0
@@ -291,7 +292,7 @@ int main(int argc, char** argv)
 		TestReader reader(true, true);
 #endif
 		for (int i = 1; i < argc; ++i) {
-			auto result = reader.read(argv[i], 0);
+			auto result = reader.read(argv[i], 0, isPure);
 			std::cout << argv[i] << ": ";
 			if (result)
 				std::cout << result.format << ": " << result.text << "\n";

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable (ZXingUnitTest
     aztec/AZEncodeDecodeTest.cpp
     aztec/AZHighLevelEncoderTest.cpp
     datamatrix/DMDecodedBitStreamParserTest.cpp
+    datamatrix/DMEncodeDecodeTest.cpp
     datamatrix/DMHighLevelEncodeTest.cpp
     datamatrix/DMPlacementTest.cpp
     datamatrix/DMSymbolInfoTest.cpp

--- a/test/unit/ReedSolomonTest.cpp
+++ b/test/unit/ReedSolomonTest.cpp
@@ -110,8 +110,8 @@ namespace {
 		int iterations = field.size() > 256 ? 1 : DECODER_RANDOM_TEST_ITERATIONS;
 		for (int i = 0; i < iterations; i++) {
 			// generate random data
-			for (int k = 0; k < dataSize; k++) {
-				dataWords[k] = random.next(0, field.size() - 1);
+			for (auto& val : dataWords) {
+				val = random.next(0, field.size() - 1);
 			}
 			// generate ECC words
 			std::copy(dataWords.begin(), dataWords.end(), message.begin());

--- a/test/unit/aztec/AZEncodeDecodeTest.cpp
+++ b/test/unit/aztec/AZEncodeDecodeTest.cpp
@@ -31,7 +31,7 @@
 
 namespace testing {
 	namespace internal {
-		bool operator==(const std::string& a, const std::wstring& b) {
+		inline bool operator==(const std::string& a, const std::wstring& b) {
 			return a.length() == b.length() && std::equal(a.begin(), a.end(), b.begin());
 		}
 	}

--- a/test/unit/datamatrix/DMEncodeDecodeTest.cpp
+++ b/test/unit/datamatrix/DMEncodeDecodeTest.cpp
@@ -1,0 +1,121 @@
+/*
+* Copyright 2017 Axel Waggershauser
+* Copyright 2013 ZXing authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#include "datamatrix/DMWriter.h"
+#include "datamatrix/DMDecoder.h"
+#include "datamatrix/DMEncoderContext.h"
+#include "DecoderResult.h"
+#include "DecodeStatus.h"
+#include "BitMatrix.h"
+#include "BitMatrixUtility.h"
+#include "PseudoRandom.h"
+#include "ZXContainerAlgorithms.h"
+
+#include "fstream"
+
+namespace testing {
+	namespace internal {
+		inline bool operator==(const std::string& a, const std::wstring& b) {
+			return a.length() == b.length() && std::equal(a.begin(), a.end(), b.begin());
+		}
+	}
+}
+
+#include "gtest/gtest.h"
+
+using namespace ZXing;
+
+namespace {
+
+	void TestEncodeDecode(const std::wstring& data, DataMatrix::SymbolShape shape = DataMatrix::SymbolShape::SQUARE)
+	{
+		DataMatrix::Writer writer;
+		writer.setShapeHint(shape);
+		BitMatrix matrix = writer.encode(data, 0, 0);
+		ASSERT_EQ(matrix.empty(), false);
+
+		DecoderResult res = DataMatrix::Decoder::Decode(matrix);
+#ifndef NDEBUG
+		if (!res.isValid())
+			Utility::WriteBitMatrixAsPBM(matrix, std::ofstream("failed-datamatrix.pbm"), 4);
+#endif
+		ASSERT_EQ(res.isValid(), true) << "size: " << data.size() << "\n"
+									   << (matrix.width() < 80 ? Utility::ToString(matrix) : std::string());
+		EXPECT_EQ(data, res.text()) << "size: " << data.size();
+	}
+}
+
+TEST(DMEncodeDecodeTest, EncodeDecodeSquare)
+{
+	std::wstring text[] = {
+	    L"Abc123!",
+	    L"Lorem ipsum. http://test/",
+	    L"AAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAAN",
+	    L"http://test/~!@#*^%&)__ ;:'\"[]{}\\|-+-=`1029384",
+	    L"http://test/~!@#*^%&)__ ;:'\"[]{}\\|-+-=`1029384756<>/?abc"
+		"Four score and seven our forefathers brought forth",
+	    L"In ut magna vel mauris malesuada dictum. Nulla ullamcorper metus quis diam"
+	    " cursus facilisis. Sed mollis quam id justo rutrum sagittis. Donec laoreet rutrum"
+		" est, nec convallis mauris condimentum sit amet. Phasellus gravida, justo et congue"
+		" auctor, nisi ipsum viverra erat, eget hendrerit felis turpis nec lorem. Nulla"
+		" ultrices, elit pellentesque aliquet laoreet, justo erat pulvinar nisi, id"
+	    " elementum sapien dolor et diam.",
+	    L"In ut magna vel mauris malesuada dictum. Nulla ullamcorper metus quis diam"
+	    " cursus facilisis. Sed mollis quam id justo rutrum sagittis. Donec laoreet rutrum"
+		" est, nec convallis mauris condimentum sit amet. Phasellus gravida, justo et congue"
+		" auctor, nisi ipsum viverra erat, eget hendrerit felis turpis nec lorem. Nulla"
+		" ultrices, elit pellentesque aliquet laoreet, justo erat pulvinar nisi, id"
+		" elementum sapien dolor et diam. Donec ac nunc sodales elit placerat eleifend."
+		" Sed ornare luctus ornare. Vestibulum vehicula, massa at pharetra fringilla, risus"
+		" justo faucibus erat, nec porttitor nibh tellus sed est. Ut justo diam, lobortis eu"
+		" tristique ac, p.In ut magna vel mauris malesuada dictum. Nulla ullamcorper metus"
+		" quis diam cursus facilisis. Sed mollis quam id justo rutrum sagittis. Donec"
+		" laoreet rutrum est, nec convallis mauris condimentum sit amet. Phasellus gravida,"
+		" justo et congue auctor, nisi ipsum viverra erat, eget hendrerit felis turpis nec"
+		" lorem. Nulla ultrices, elit pellentesque aliquet laoreet, justo erat pulvinar"
+		" nisi, id elementum sapien dolor et diam. Donec ac nunc sodales elit placerat"
+		" eleifend. Sed ornare luctus ornare. Vestibulum vehicula, massa at pharetra"
+		" fringilla, risus justo faucibus erat, nec porttitor nibh tellus sed est. Ut justo"
+		" diam, lobortis eu tristique ac, p. In ut magna vel mauris malesuada dictum. Nulla"
+		" ullamcorper metus quis diam cursus facilisis. Sed mollis quam id justo rutrum"
+		" sagittis. Donec laoreet rutrum est, nec convallis mauris condimentum sit amet."
+		" Phasellus gravida, justo et congue auctor, nisi ipsum viverra erat, eget hendrerit"
+		" felis turpis nec lorem. Nulla ultrices, elit pellentesque aliquet laoreet, justo"
+		" erat pulvinar nisi, id elementum sapien dolor et diam.",
+	};
+
+	for (auto data : text)
+		TestEncodeDecode(data);
+}
+
+TEST(DMEncodeDecodeTest, EncodeDecodeRectangle)
+{
+	std::wstring text[] = {
+	    L"Abc123!",
+	    L"Lorem ipsum. http://test/",
+	    L"AAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAAN",
+	    L"http://test/~!@#*^%&)__ ;:'\"[]{}\\|-+-=`1029384",
+	};
+
+	for (auto data : text)
+		TestEncodeDecode(data, DataMatrix::SymbolShape::RECTANGLE);
+}
+
+TEST(DMEncodeDecodeTest, EDIFACTWithEOD)
+{
+	TestEncodeDecode(L"abc<->ABCDE");
+}
+

--- a/test/unit/datamatrix/DMHighLevelEncodeTest.cpp
+++ b/test/unit/datamatrix/DMHighLevelEncodeTest.cpp
@@ -18,6 +18,7 @@
 #include "ByteArray.h"
 #include "datamatrix/DMHighLevelEncoder.h"
 #include "datamatrix/DMSymbolInfo.h"
+#include "datamatrix/DMSymbolShape.h"
 #include "ZXContainerAlgorithms.h"
 
 namespace ZXing {
@@ -351,6 +352,14 @@ TEST(DMHighLevelEncodeTest, EncodingWithStartAsX12AndLatchToEDIFACTInTheMiddle)
 {
     std::string visualized = HighLevelEncode(L"*MEMANT-1F-MESTECH");
     EXPECT_EQ(visualized, "238 10 99 164 204 254 240 82 220 70 180 209 83 80 80 200");
+}
+
+TEST(DMHighLevelEncodeTest, EDIFACTWithEODBug)
+{
+	std::string visualized = Visualize(
+		DataMatrix::HighLevelEncoder::Encode(L"abc<->ABCDE", DataMatrix::SymbolShape::SQUARE, -1, -1, -1, -1));
+    // switch to EDIFACT on '<', uses 10 code words + 2 padding. Buggy code introduced invalid 254 after the 5
+    EXPECT_EQ(visualized, "98 99 100 240 242 223 129 8 49 5 129 147");
 }
 
 //  @Ignore

--- a/test/unit/datamatrix/DMHighLevelEncodeTest.cpp
+++ b/test/unit/datamatrix/DMHighLevelEncodeTest.cpp
@@ -347,6 +347,12 @@ TEST(DMHighLevelEncodeTest, MacroCharacters)
 	EXPECT_EQ(visualized, "236 185 185 29 196 196 129 56");
 }
 
+TEST(DMHighLevelEncodeTest, EncodingWithStartAsX12AndLatchToEDIFACTInTheMiddle)
+{
+    std::string visualized = HighLevelEncode(L"*MEMANT-1F-MESTECH");
+    EXPECT_EQ(visualized, "238 10 99 164 204 254 240 82 220 70 180 209 83 80 80 200");
+}
+
 //  @Ignore
 //  @Test  
 //  public void testDataURL() {

--- a/test/unit/datamatrix/DMPlacementTest.cpp
+++ b/test/unit/datamatrix/DMPlacementTest.cpp
@@ -16,41 +16,27 @@
 */
 #include "gtest/gtest.h"
 #include "ByteMatrix.h"
+#include "ByteMatrixUtility.h"
+#include "ByteArray.h"
 #include "datamatrix/DMDefaultPlacement.h"
+
+#include <sstream>
+#include <iterator>
 
   //private static final Pattern SPACE = Pattern.compile(" ");
 
+using namespace ZXing;
+using namespace ZXing::DataMatrix;
+
 namespace {
 
-	std::vector<int> Unvisualize(const std::string& visualized) {
-		std::vector<int> result;
-		std::string::size_type prev = 0;
-		auto index = visualized.find(' ');
-		while (index != std::string::npos) {
-			visualized.substr(prev, index - prev);
-			result.push_back(std::stoi(visualized.substr(prev, index - prev)));
-			prev = index + 1;
-			index = visualized.find(' ', prev);
-		}
-		result.push_back(std::stoi(visualized.substr(prev)));
-		return result;
-	}
-
-	std::string ToString(const ZXing::ByteMatrix& matrix)
-	{
-		std::string result;
-		result.reserve((matrix.width() + 1) * matrix.height());
-		for (int y = 0; y < matrix.height(); ++y) {
-			for (int x = 0; x < matrix.width(); ++x) {
-				result.push_back(matrix.get(x, y) == 1 ? '1' : '0');
-			}
-			result.push_back('\n');
-		}
+	ByteArray Unvisualize(const char* visualized) {
+		std::istringstream input(visualized);
+		ByteArray result;
+		std::copy(std::istream_iterator<int>(input), std::istream_iterator<int>(), std::back_inserter(result));
 		return result;
 	}
 }
-
-using namespace ZXing::DataMatrix;
 
 TEST(DMPlacementTest, Placement)
 {
@@ -69,5 +55,5 @@ TEST(DMPlacementTest, Placement)
         "100010010111\n"
         "011101011010\n"
         "001011001010\n";
-    EXPECT_EQ(expected, ToString(matrix));
+    EXPECT_EQ(expected, Utility::ToString(matrix, '1', '0', ' ', false));
   }

--- a/test/unit/datamatrix/DMWriterTest.cpp
+++ b/test/unit/datamatrix/DMWriterTest.cpp
@@ -16,9 +16,11 @@
 */
 #include "gtest/gtest.h"
 #include "BitMatrix.h"
+#include "BitMatrixUtility.h"
 #include "datamatrix/DMWriter.h"
 #include "datamatrix/DMSymbolShape.h"
 
+using namespace ZXing;
 using namespace ZXing::DataMatrix;
 
 TEST(DMWriterTest, ImageWriter)
@@ -49,4 +51,102 @@ TEST(DMWriterTest, TooSmallSize)
 	auto matrix = writer.encode(L"http://www.google.com/", tooSmall, tooSmall);
 	EXPECT_GT(matrix.width(), tooSmall);
 	EXPECT_GT(matrix.height(), tooSmall);
+}
+
+static void DoTest(const std::wstring& text, SymbolShape shape, const char* expected)
+{
+	Writer writer;
+	writer.setShapeHint(shape);
+	auto matrix = writer.encode(text, 0, 0);
+	auto actual = Utility::ToString(matrix, 'X', ' ', true);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(DMWriterTest, Small)
+{
+	DoTest(L"0", SymbolShape::SQUARE,
+	       "X   X   X   X   X   \n"
+	       "X X   X X     X   X \n"
+	       "X       X X     X   \n"
+	       "X     X           X \n"
+	       "X     X   X X X X   \n"
+	       "X X X X X X       X \n"
+	       "X       X   X       \n"
+	       "X X     X X X   X X \n"
+	       "X   X       X       \n"
+	       "X X X X X X X X X X \n" );
+}
+
+TEST(DMWriterTest, Rectangle)
+{
+	DoTest(L"abcde", SymbolShape::RECTANGLE,
+	       "X   X   X   X   X   X   X   X   X   \n"
+	       "X   X X     X     X     X   X X   X \n"
+	       "X X       X X   X     X   X X       \n"
+	       "X   X X X     X     X X   X X   X X \n"
+	       "X     X X X   X X X X X X X X X     \n"
+	       "X   X X     X     X X X X       X X \n"
+	       "X X   X X X       X X X X X   X X   \n"
+	       "X X X X X X X X X X X X X X X X X X \n");
+}
+
+TEST(DMWriterTest, Large)
+{
+	auto text = L"123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-"
+				L"123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-"
+				L"123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-";
+	auto expected =
+		"X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   \n"
+		"X X     X     X   X   X     X X X X     X     X   X X     X X       X X X   X   X   X     X X       X X \n"
+		"X X                   X X X   X   X                 X X X X X   X X     X   X   X X   X X X X   X X     \n"
+		"X X     X X X     X X     X   X   X     X X X X X X X   X   X     X             X X X   X   X     X   X \n"
+		"X X       X   X   X               X       X     X   X   X   X     X X X X   X X     X   X   X           \n"
+		"X   X   X     X X   X X X     X X   X   X X       X X   X X X X     X   X     X         X X X   X X X X \n"
+		"X   X X   X X X       X   X   X X   X X   X X X X   X X   X   X     X   X     X X X X X   X       X X   \n"
+		"X   X X X   X   X   X     X X       X X     X     X X X   X   X     X X X X     X     X   X           X \n"
+		"X X     X   X   X X   X X X X   X X   X             X         X X X   X   X               X X   X X X   \n"
+		"X X             X X X   X   X     X   X     X X X X X     X X     X   X   X     X X X X       X   X X X \n"
+		"X X X X X   X X     X   X   X         X       X     X X   X               X       X           X X X     \n"
+		"X   X   X     X         X X X     X X   X   X     X X X X   X X X     X X   X   X         X X X   X   X \n"
+		"X   X   X     X X X X X   X   X   X X   X X   X X   X X       X   X   X X   X X   X   X     X   X X     \n"
+		"X   X X X X     X     X       X X       X X X   X X X   X   X     X X       X     X X       X X X X   X \n"
+		"X X   X   X               X X X X   X X     X   X   X   X X   X X X X   X X   X X X X   X   X     X X   \n"
+		"X X   X   X     X X X X X   X   X     X           X X   X X X   X   X     X X   X   X     X X   X X   X \n"
+		"X         X       X     X   X   X     X X X X   X   X X     X   X   X       X         X X   X X   X     \n"
+		"X     X X   X   X X         X X X X     X   X     X X X         X X X X         X X X     X X   X X   X \n"
+		"X X   X X   X X   X X X X X   X   X     X   X       X X X X X X   X   X X X X X   X   X     X X X   X   \n"
+		"X X X       X X     X     X   X   X     X X X X   X X   X     X   X     X     X     X X     X   X     X \n"
+		"X X X   X X   X                   X X X   X   X     X             X       X       X   X   X X X X X X   \n"
+		"X   X     X   X     X X X     X X     X   X   X   X X   X X X X   X     X             X     X X X   X X \n"
+		"X   X         X       X   X   X               X     X     X       X X X X X X   X   X   X X X   X X X   \n"
+		"X X X     X X   X   X     X X   X X X     X X   X X X   X     X X   X X X             X   X       X X X \n"
+		"X X   X   X X   X X   X X X       X   X   X X   X   X X   X   X X   X   X     X X X X X X     X   X     \n"
+		"X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X \n"
+		"X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   X   \n"
+		"X     X X       X X X   X   X   X     X X       X X X     X X     X   X X X X X X   X X   X X       X X \n"
+		"X X X X X   X X     X   X   X X   X X X X   X X     X X X X     X   X   X X           X       X X   X   \n"
+		"X   X   X     X             X X X   X   X     X X X X   X   X   X       X X           X X         X X X \n"
+		"X   X   X     X X X X   X X     X   X   X       X   X   X X X               X     X X X X   X   X   X   \n"
+		"X   X X X X     X   X     X         X X X X       X X         X     X   X     X X     X   X X   X     X \n"
+		"X X   X   X     X   X     X X X X X   X   X X X     X X   X   X         X X X   X X     X X     X   X   \n"
+		"X X   X   X     X X X X     X     X   X     X     X X X X X         X X   X   X     X X   X X X X     X \n"
+		"X         X X X   X   X               X     X X     X   X       X X X     X       X   X X   X     X     \n"
+		"X     X X     X   X   X     X X X X   X     X   X X X   X X     X   X       X X   X   X   X       X X X \n"
+		"X X   X               X       X       X X   X X X   X   X       X       X X X   X   X X     X X   X X   \n"
+		"X X X   X X X     X X   X   X     X X           X X X X     X X X X X   X     X X X   X     X         X \n"
+		"X X       X   X   X X   X X   X   X     X X X       X X   X X       X X X   X X     X   X     X   X X   \n"
+		"X   X   X     X X       X     X X     X X     X   X X X   X   X X   X           X X       X X X X   X X \n"
+		"X   X X   X X X X   X X   X X X X   X X   X X X     X     X X X           X       X X X X X X       X   \n"
+		"X   X X X   X   X     X X   X   X X   X         X X X           X X     X X X X     X X   X X         X \n"
+		"X X     X   X   X       X     X X       X X     X   X X   X     X X         X   X X X X X X   X     X   \n"
+		"X X         X X X X             X X X     X X X X X X         X X X   X X X X X X X X X X X       X   X \n"
+		"X X X X X X   X   X X X X X   X X     X X X   X     X       X     X X       X X X       X X   X     X   \n"
+		"X   X     X   X     X   X     X X X X     X X     X X     X X X   X   X X X X X X   X   X     X   X   X \n"
+		"X             X       X     X   X   X               X   X X   X X   X     X X           X X   X X X     \n"
+		"X   X X X X   X     X X X X   X     X     X   X X X X   X   X X X     X X   X             X X X   X   X \n"
+		"X     X       X           X     X X     X     X X   X     X X X       X   X       X   X   X     X       \n"
+		"X   X X   X X     X   X   X X   X   X X       X   X X         X X X X   X           X   X           X X \n"
+		"X X   X X X X X       X     X         X X X X X     X     X   X X         X X X     X     X   X X   X   \n"
+		"X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X \n";
+	DoTest(text, SymbolShape::SQUARE, expected);
 }


### PR DESCRIPTION
1. port a bug fix from upstream
2. fix a bug introduced during c++ port
3. fix a bug that is presumably still in upstream (see EDIFACT unlatching)

Just found out: the 3rd bug has been detected in the up-upstream project 5 years ago: https://sourceforge.net/p/barcode4j/bugs/38/