### PR TITLE
DM Encoder fixes and more readability improvements

### DIFF
--- a/core/src/BitMatrix.h
+++ b/core/src/BitMatrix.h
@@ -22,6 +22,7 @@
 namespace ZXing {
 
 class BitArray;
+class ByteMatrix;
 
 /**
 * <p>Represents a 2D matrix of bits. In function arguments below, and throughout the common
@@ -55,6 +56,8 @@ public:
 	BitMatrix(int width, int height) : _width(width), _height(height), _rowSize((width + 31) / 32), _bits(((width + 31) / 32) * _height, 0) {}
 
 	explicit BitMatrix(int dimension) : BitMatrix(dimension, dimension) {} // Construct a square matrix.
+
+	BitMatrix(const ByteMatrix& other, int blackValue);
 
 	BitMatrix(BitMatrix&& other) noexcept : _width(other._width), _height(other._height), _rowSize(other._rowSize), _bits(std::move(other._bits)) {}
 
@@ -153,6 +156,11 @@ public:
 	void setRow(int y, const BitArray& row);
 
 	/**
+	* Modifies this {@code BitMatrix} to represent the same but rotated 90 degrees clockwise
+	*/
+	void rotate90();
+
+	/**
 	* Modifies this {@code BitMatrix} to represent the same but rotated 180 degrees
 	*/
 	void rotate180();
@@ -205,5 +213,27 @@ public:
 		return a._width == b._width && a._height == b._height && a._rowSize == b._rowSize && a._bits == b._bits;
 	}
 };
+
+/**
+ * @brief Inflate scales a BitMatrix up and adds a quite Zone plus padding
+ * @param matrix input to be expanded
+ * @param width new width in bits (pixel)
+ * @param height new height in bits (pixel)
+ * @param quietZone size of quite zone to add in modules
+ * @return expanded BitMatrix, maybe move(input) if size did not change
+ */
+BitMatrix Inflate(BitMatrix&& input, int width, int height, int quietZone);
+
+/**
+ * @brief Deflate (crop + subsample) a bit matrix
+ * @param matrix
+ * @param width new width
+ * @param height new height
+ * @param top cropping starts at top row
+ * @param left cropping starts at left col
+ * @param subSampling typically the module size
+ * @return deflated input
+ */
+BitMatrix Deflate(const BitMatrix& matrix, int width, int height, int top, int left, int subSampling);
 
 } // ZXing

--- a/core/src/aztec/AZWriter.cpp
+++ b/core/src/aztec/AZWriter.cpp
@@ -25,30 +25,6 @@
 namespace ZXing {
 namespace Aztec {
 
-static BitMatrix RenderResult(const BitMatrix &input, int width, int height)
-{
-	int inputWidth = input.width();
-	int inputHeight = input.height();
-	int outputWidth = std::max(width, inputWidth);
-	int outputHeight = std::max(height, inputHeight);
-	if (outputWidth == inputWidth && outputHeight == inputHeight)
-		return input.copy();
-
-	int multiple = std::min(outputWidth / inputWidth, outputHeight / inputHeight);
-	int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
-	int topPadding = (outputHeight - (inputHeight * multiple)) / 2;
-
-	BitMatrix result(outputWidth, outputHeight);
-	for (int inputY = 0, outputY = topPadding; inputY < inputHeight; inputY++, outputY += multiple) {
-		for (int inputX = 0, outputX = leftPadding; inputX < inputWidth; inputX++, outputX += multiple) {
-			if (input.get(inputX, inputY)) {
-				result.setRegion(outputX, outputY, multiple, multiple);
-			}
-		}
-	}
-	return result;
-}
-
 Writer::Writer() :
 	_encoding(CharacterSet::ISO8859_1),
 	_eccPercent(Encoder::DEFAULT_EC_PERCENT),
@@ -62,7 +38,8 @@ Writer::encode(const std::wstring& contents, int width, int height) const
 	std::string bytes;
 	TextEncoder::GetBytes(contents, _encoding, bytes);
 	EncodeResult aztec = Encoder::Encode(bytes, _eccPercent, _layers);
-	return RenderResult(aztec.matrix, width, height);
+	// Minimum required quite zone for Aztec is 0
+	return Inflate(std::move(aztec.matrix), width, height, 0);
 }
 
 } // Aztec

--- a/core/src/datamatrix/DMDefaultPlacement.cpp
+++ b/core/src/datamatrix/DMDefaultPlacement.cpp
@@ -24,90 +24,33 @@
 namespace ZXing {
 namespace DataMatrix {
 
-//inline static bool getBit(const ThreeStateBoolArray& bits, int col, int row)
-//{
-//	return bits[row * numcols + col] == 1;
-//}
-//
-//inline static void setBit(ThreeStateBoolArray& bits, int col, int row, boolean bit) {
-//	bits[row * numcols + col] = (byte)(bit ? 1 : 0);
-//}
-//
-//final boolean hasBit(int col, int row) {
-//	return bits[row * numcols + col] >= 0;
-//}
-
-template <class GetBitPosFunc>
-static void PlaceCodeword(uint8_t codeword, ByteMatrix& matrix, GetBitPosFunc getBitPos)
-{
-	for (int bit = 0; bit < 8; ++bit) {
-		BitPos p = getBitPos(matrix, bit);
-		bool value = codeword & (1 << (7 - bit));
-		matrix.set(p.col, p.row, value);
-	}
-}
-
 ByteMatrix DefaultPlacement::Place(const ByteArray& codewords, int numCols, int numRows)
 {
-	ByteMatrix bits(numCols, numRows, -1);
+	ByteMatrix result(numCols, numRows, -1);
 
 	auto codeword = codewords.begin();
-	// Places the 8 bits of one of the special corner symbols.
-	auto placeCorner = [&](const BitPosArray& corner) {
-		PlaceCodeword(*codeword++, bits, [&](const ByteMatrix& matrix, int bit){
-			return GetCornerBitPos(matrix, bit, corner);
-		});
-	};
-	// Places the 8 bits of a utah-shaped symbol character in ECC200.
-	auto placeUtah = [&](int row, int col) {
-		PlaceCodeword(*codeword++, bits, [&](const ByteMatrix& matrix, int bit){
-			return GetUtahBitPos(matrix, bit, row, col);
-		});
-	};
 
-	int row = 4;
-	int col = 0;
+	VisitMatrix(numRows, numCols, [&codeword, &result](const BitPosArray& bitPos) {
+		// Places the 8 bits of a corner or the utah-shaped symbol character in the result matrix
+		uint8_t mask = 0x80;
+		for (auto& p : bitPos) {
+			bool value = *codeword & mask;
+			result.set(p.col, p.row, value);
+			mask >>= 1;
+		}
+		++codeword;
+	});
 
-	do {
-		/* repeatedly first check for one of the special corner cases, then... */
-		if ((row == numRows) && (col == 0))
-			placeCorner(CORNER1);
-		else if ((row == numRows - 2) && (col == 0) && (numCols % 4 != 0))
-			placeCorner(CORNER2);
-		else if ((row == numRows + 4) && (col == 2) && (numCols % 8 == 0))
-			placeCorner(CORNER3);
-		else if ((row == numRows - 2) && (col == 0) && (numCols % 8 == 4))
-			placeCorner(CORNER4);
+	if (codeword != codewords.end())
+		return {};
 
-		/* sweep upward diagonally, inserting successive characters... */
-		do {
-			if ((row < numRows) && (col >= 0) && bits.get(col, row) < 0) {
-				placeUtah(row, col);
-			}
-			row -= 2;
-			col += 2;
-		} while (row >= 0 && col < numCols);
-		row += 1;
-		col += 3;
-
-		/* and then sweep downward diagonally, inserting successive characters, ... */
-		do {
-			if ((row >= 0) && (col < numCols) && bits.get(col, row) < 0) {
-				placeUtah(row, col);
-			}
-			row += 2;
-			col -= 2;
-		} while ((row < numRows) && (col >= 0));
-		row += 3;
-		col += 1;
-	} while ((row < numRows) || (col < numCols));
-
-	/* Lastly, if the lower righthand corner is untouched, fill in fixed pattern */
-	if (bits.get(numCols - 1, numRows - 1) < 0) {
-		bits.set(numCols - 1, numRows - 1, true);
-		bits.set(numCols - 2, numRows - 2, true);
+	// Lastly, if the lower righthand corner is untouched, fill in fixed pattern
+	if (result.get(numCols - 1, numRows - 1) < 0) {
+		result.set(numCols - 1, numRows - 1, true);
+		result.set(numCols - 2, numRows - 2, true);
 	}
-	return bits;
+
+	return result;
 }
 
 } // DataMatrix

--- a/core/src/datamatrix/DMDefaultPlacement.cpp
+++ b/core/src/datamatrix/DMDefaultPlacement.cpp
@@ -47,9 +47,9 @@ static void PlaceCodeword(uint8_t codeword, ByteMatrix& matrix, GetBitPosFunc ge
 	}
 }
 
-ByteMatrix DefaultPlacement::Place(const ByteArray& codewords, int numcols, int numrows)
+ByteMatrix DefaultPlacement::Place(const ByteArray& codewords, int numCols, int numRows)
 {
-	ByteMatrix bits(numcols, numrows, -1);
+	ByteMatrix bits(numCols, numRows, -1);
 
 	auto codeword = codewords.begin();
 	// Places the 8 bits of one of the special corner symbols.
@@ -70,47 +70,42 @@ ByteMatrix DefaultPlacement::Place(const ByteArray& codewords, int numcols, int 
 
 	do {
 		/* repeatedly first check for one of the special corner cases, then... */
-		if ((row == numrows) && (col == 0)) {
+		if ((row == numRows) && (col == 0))
 			placeCorner(CORNER1);
-		}
-		if ((row == numrows - 2) && (col == 0) && ((numcols % 4) != 0)) {
+		else if ((row == numRows - 2) && (col == 0) && (numCols % 4 != 0))
 			placeCorner(CORNER2);
-		}
-		if ((row == numrows + 4) && (col == 2) && ((numcols % 8) == 0)) {
+		else if ((row == numRows + 4) && (col == 2) && (numCols % 8 == 0))
 			placeCorner(CORNER3);
-		}
-		if ((row == numrows - 2) && (col == 0) && (numcols % 8 == 4)) {
+		else if ((row == numRows - 2) && (col == 0) && (numCols % 8 == 4))
 			placeCorner(CORNER4);
-		}
+
 		/* sweep upward diagonally, inserting successive characters... */
 		do {
-			if ((row < numrows) && (col >= 0) && bits.get(col, row) < 0) {
+			if ((row < numRows) && (col >= 0) && bits.get(col, row) < 0) {
 				placeUtah(row, col);
 			}
 			row -= 2;
 			col += 2;
-		} while (row >= 0 && (col < numcols));
-		row++;
+		} while (row >= 0 && col < numCols);
+		row += 1;
 		col += 3;
 
 		/* and then sweep downward diagonally, inserting successive characters, ... */
 		do {
-			if ((row >= 0) && (col < numcols) && bits.get(col, row) < 0) {
+			if ((row >= 0) && (col < numCols) && bits.get(col, row) < 0) {
 				placeUtah(row, col);
 			}
 			row += 2;
 			col -= 2;
-		} while ((row < numrows) && (col >= 0));
+		} while ((row < numRows) && (col >= 0));
 		row += 3;
-		col++;
-
-		/* ...until the entire array is scanned */
-	} while ((row < numrows) || (col < numcols));
+		col += 1;
+	} while ((row < numRows) || (col < numCols));
 
 	/* Lastly, if the lower righthand corner is untouched, fill in fixed pattern */
-	if (bits.get(numcols - 1, numrows - 1) < 0) {
-		bits.set(numcols - 1, numrows - 1, true);
-		bits.set(numcols - 2, numrows - 2, true);
+	if (bits.get(numCols - 1, numRows - 1) < 0) {
+		bits.set(numCols - 1, numRows - 1, true);
+		bits.set(numCols - 2, numRows - 2, true);
 	}
 	return bits;
 }

--- a/core/src/datamatrix/DMDefaultPlacement.h
+++ b/core/src/datamatrix/DMDefaultPlacement.h
@@ -15,14 +15,56 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include <vector>
+
+#include "ByteMatrix.h"
+
+#include <array>
 
 namespace ZXing {
 
-class ByteMatrix;
 class ByteArray;
 
 namespace DataMatrix {
+
+struct BitPos
+{
+	int row, col;
+};
+
+using BitPosArray = std::array<BitPos, 8>;
+
+/**
+ * <p>See ISO 16022:2006, Figure F.3 to F.6</p>
+ */
+constexpr BitPosArray CORNER1 = {{{-1, 0}, {-1, 1}, {-1, 2}, {0, -2}, {0, -1}, {1, -1}, {2, -1}, {3, -1}}};
+constexpr BitPosArray CORNER2 = {{{-3, 0}, {-2, 0}, {-1, 0}, {0, -4}, {0, -3}, {0, -2}, {0, -1}, {1, -1}}};
+constexpr BitPosArray CORNER3 = {{{-1, 0}, {-1, -1}, {0, -3}, {0, -2}, {0, -1}, {1, -3}, {1, -2}, {1, -1}}};
+constexpr BitPosArray CORNER4 = {{{-3, 0}, {-2, 0}, {-1, 0}, {0, -2}, {0, -1}, {1, -1}, {2, -1}, {3, -1}}};
+
+template <class Matrix>
+BitPos GetCornerBitPos(const Matrix& matrix, int bit, const BitPosArray& corner)
+{
+	auto clamp = [](int i, int max) { return i < 0 ? i + max : i; };
+	return {clamp(corner[bit].row, matrix.height()), clamp(corner[bit].col, matrix.width())};
+}
+
+template <class Matrix>
+BitPos GetUtahBitPos(const Matrix& matrix, int bit, int row, int col)
+{
+	const BitPosArray delta = {{{-2, -2}, {-2, -1}, {-1, -2}, {-1, -1}, {-1, 0}, {0, -2}, {0, -1}, {0, 0}}};
+
+	row += delta[bit].row;
+	col += delta[bit].col;
+	if (row < 0) {
+		row += matrix.height();
+		col += 4 - ((matrix.height() + 4) % 8);
+	}
+	if (col < 0) {
+		col += matrix.width();
+		row += 4 - ((matrix.width() + 4) % 8);
+	}
+	return {row, col};
+}
 
 /**
 * Symbol Character Placement Program. Adapted from Annex M.1 in ISO/IEC 16022:2000(E).

--- a/core/src/datamatrix/DMHighLevelEncoder.cpp
+++ b/core/src/datamatrix/DMHighLevelEncoder.cpp
@@ -740,7 +740,7 @@ namespace EdifactEncoder {
 				auto symbolInfo = context.updateSymbolInfo(codewordCount);
 				int available = symbolInfo->dataCapacity() - codewordCount;
 				int remaining = context.remainingCharacters();
-				if (remaining == 0 && available <= 2) {
+				if (remaining <= available && available <= 2) {
 					return; //No unlatch
 				}
 			}

--- a/core/src/datamatrix/DMHighLevelEncoder.cpp
+++ b/core/src/datamatrix/DMHighLevelEncoder.cpp
@@ -422,12 +422,12 @@ namespace C40Encoder {
 		throw std::invalid_argument("Illegal character: " + ToHexString(c));
 	}
 
-	static int BacktrackOneCharacter(EncoderContext& context, std::string& buffer, std::string& removed, int lastCharSize)
+	static int BacktrackOneCharacter(EncoderContext& context, std::string& buffer, std::string& removed, int lastCharSize, std::function<int (int, std::string&)> encodeChar)
 	{
 		buffer.resize(buffer.size() - lastCharSize);
 		context.setCurrentPos(context.currentPos() - 1);
 		int c = context.currentChar();
-		lastCharSize = EncodeChar(c, removed);
+		lastCharSize = encodeChar(c, removed);
 		context.resetSymbolInfo(); //Deal with possible reduction in symbol size
 		return lastCharSize;
 	}
@@ -513,11 +513,11 @@ namespace C40Encoder {
 				std::string removed;
 				if ((buffer.length() % 3) == 2) {
 					if (available < 2 || available > 2) {
-						lastCharSize = BacktrackOneCharacter(context, buffer, removed, lastCharSize);
+						lastCharSize = BacktrackOneCharacter(context, buffer, removed, lastCharSize, encodeChar);
 					}
 				}
 				while ((buffer.length() % 3) == 1 && ((lastCharSize <= 3 && available != 1) || lastCharSize > 3)) {
-					lastCharSize = BacktrackOneCharacter(context, buffer, removed, lastCharSize);
+					lastCharSize = BacktrackOneCharacter(context, buffer, removed, lastCharSize, encodeChar);
 				}
 				break;
 			}

--- a/core/src/datamatrix/DMReader.cpp
+++ b/core/src/datamatrix/DMReader.cpp
@@ -72,17 +72,8 @@ ExtractPureBits(const BitMatrix& image)
 	top += nudge;
 	left += nudge;
 
-	// Now just read off the bits
-	BitMatrix result(matrixWidth, matrixHeight);
-	for (int y = 0; y < matrixHeight; y++) {
-		int iOffset = top + y * moduleSize;
-		for (int x = 0; x < matrixWidth; x++) {
-			if (image.get(left + x * moduleSize, iOffset)) {
-				result.set(x, y);
-			}
-		}
-	}
-	return result;
+	// Now just read off the bits (this is a crop + subsample)
+	return Deflate(image, matrixWidth, matrixHeight, top, left, moduleSize);
 }
 
 Reader::Reader(const DecodeHints& hints) : _tryRotate(hints.shouldTryRotate()), _tryHarder(hints.shouldTryHarder())

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -130,17 +130,8 @@ ExtractPureBits(const BitMatrix& image)
 		top -= nudgedTooFarDown;
 	}
 
-	// Now just read off the bits
-	BitMatrix result(matrixWidth, matrixHeight);
-	for (int y = 0; y < matrixHeight; y++) {
-		int iOffset = top + (int)(y * moduleSize);
-		for (int x = 0; x < matrixWidth; x++) {
-			if (image.get(left + (int)(x * moduleSize), iOffset)) {
-				result.set(x, y);
-			}
-		}
-	}
-	return result;
+	// Now just read off the bits (this is a crop + subsample)
+	return Deflate(image, matrixWidth, matrixHeight, top, left, static_cast<int>(moduleSize));
 }
 
 Reader::Reader(const DecodeHints& hints) :

--- a/core/src/qrcode/QRWriter.cpp
+++ b/core/src/qrcode/QRWriter.cpp
@@ -27,37 +27,6 @@ namespace QRCode {
 
 static const int QUIET_ZONE_SIZE = 4;
 
-static BitMatrix RenderResult(const ByteMatrix& input, int width, int height, int quietZone)
-{
-	int inputWidth = input.width();
-	int inputHeight = input.height();
-	int qrWidth = inputWidth + (quietZone * 2);
-	int qrHeight = inputHeight + (quietZone * 2);
-	int outputWidth = std::max(width, qrWidth);
-	int outputHeight = std::max(height, qrHeight);
-
-	int multiple = std::min(outputWidth / qrWidth, outputHeight / qrHeight);
-	// Padding includes both the quiet zone and the extra white pixels to accommodate the requested
-	// dimensions. For example, if input is 25x25 the QR will be 33x33 including the quiet zone.
-	// If the requested size is 200x160, the multiple will be 4, for a QR of 132x132. These will
-	// handle all the padding from 100x100 (the actual QR) up to 200x160.
-	int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
-	int topPadding = (outputHeight - (inputHeight * multiple)) / 2;
-
-	BitMatrix result(outputWidth, outputHeight);
-
-	for (int inputY = 0, outputY = topPadding; inputY < inputHeight; inputY++, outputY += multiple) {
-		// Write the contents of this row of the barcode
-		for (int inputX = 0, outputX = leftPadding; inputX < inputWidth; inputX++, outputX += multiple) {
-			if (input.get(inputX, inputY) == 1) {
-				result.setRegion(outputX, outputY, multiple, multiple);
-			}
-		}
-	}
-
-	return result;
-}
-
 Writer::Writer() :
 	_margin(QUIET_ZONE_SIZE),
 	_ecLevel(ErrorCorrectionLevel::Low),
@@ -78,7 +47,7 @@ Writer::encode(const std::wstring& contents, int width, int height) const
 	}
 
 	EncodeResult code = Encoder::Encode(contents, _ecLevel, _encoding, _version);
-	return RenderResult(code.matrix, width, height, _margin);
+	return Inflate(BitMatrix(code.matrix, 1), width, height, _margin);
 }
 
 } // QRCode

--- a/test/unit/aztec/AZDetectorTest.cpp
+++ b/test/unit/aztec/AZDetectorTest.cpp
@@ -48,47 +48,9 @@ namespace {
 		return result;
 	}
 
-	// Rotates a square BitMatrix to the right by 90 degrees
-	void RotateRight(BitMatrix& input) {
-		int width = input.width();
-		BitMatrix result(width);
-		for (int x = 0; x < width; x++) {
-			for (int y = 0; y < width; y++) {
-				if (input.get(x, y)) {
-					result.set(y, width - x - 1);
-				}
-			}
-		}
-		input = std::move(result);
-	}
-
-	// Returns the transpose of a bit matrix, which is equivalent to rotating the
-	// matrix to the right, and then flipping it left-to-right
-	void Transpose(BitMatrix& input) {
-		int width = input.width();
-		BitMatrix result(width);
-		for (int x = 0; x < width; x++) {
-			for (int y = 0; y < width; y++) {
-				if (input.get(x, y)) {
-					result.set(y, x);
-				}
-			}
-		}
-		input = std::move(result);
-	}
-
 	// Zooms a bit matrix so that each bit is factor x factor
 	BitMatrix MakeLarger(const BitMatrix& input, int factor) {
-		int width = input.width();
-		BitMatrix output(width * factor);
-		for (int inputY = 0; inputY < width; inputY++) {
-			for (int inputX = 0; inputX < width; inputX++) {
-				if (input.get(inputX, inputY)) {
-					output.setRegion(inputX * factor, inputY * factor, factor, factor);
-				}
-			}
-		}
-		return output;
+		return Inflate(input.copy(), factor * input.width(), factor * input.height(), 0);
 	}
 
 	// Test that we can tolerate errors in the parameter locator bits
@@ -104,7 +66,7 @@ namespace {
 					for (int error2 = error1; error2 < (int)orientationPoints.size(); error2++) {
 						BitMatrix copy = matrix.copy();
 						if (isMirror) {
-							Transpose(copy);
+							copy.mirror();
 						}
 						copy.flip(orientationPoints[error1].x, orientationPoints[error1].y);
 						if (error2 > error1) {
@@ -134,7 +96,7 @@ namespace {
 					EXPECT_EQ(r.isValid(), false);
 				}
 
-				RotateRight(matrix);
+				matrix.rotate90();
 			}
 		}
 	}

--- a/test/unit/datamatrix/DMEncodeDecodeTest.cpp
+++ b/test/unit/datamatrix/DMEncodeDecodeTest.cpp
@@ -49,12 +49,15 @@ namespace {
 
 		DecoderResult res = DataMatrix::Decoder::Decode(matrix);
 #ifndef NDEBUG
-		if (!res.isValid())
+		if (!res.isValid() || data != res.text())
 			Utility::WriteBitMatrixAsPBM(matrix, std::ofstream("failed-datamatrix.pbm"), 4);
 #endif
-		ASSERT_EQ(res.isValid(), true) << "size: " << data.size() << "\n"
+		ASSERT_EQ(res.isValid(), true) << "text size: " << data.size() << ", code size: " << matrix.height() << "x"
+									   << matrix.width() << "\n"
 									   << (matrix.width() < 80 ? Utility::ToString(matrix) : std::string());
-		EXPECT_EQ(data, res.text()) << "size: " << data.size();
+		EXPECT_EQ(data, res.text()) << "text size: " << data.size() << ", code size: " << matrix.height() << "x"
+									<< matrix.width() << "\n"
+									<< (matrix.width() < 80 ? Utility::ToString(matrix) : std::string());
 	}
 }
 
@@ -108,10 +111,12 @@ TEST(DMEncodeDecodeTest, EncodeDecodeRectangle)
 	    L"Lorem ipsum. http://test/",
 	    L"AAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAANAAAAN",
 	    L"http://test/~!@#*^%&)__ ;:'\"[]{}\\|-+-=`1029384",
+	    L"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 	};
 
 	for (auto data : text)
-		TestEncodeDecode(data, DataMatrix::SymbolShape::RECTANGLE);
+		for (size_t len	= 1; len <= data.size(); ++len)
+			TestEncodeDecode(data.substr(0, len), DataMatrix::SymbolShape::RECTANGLE);
 }
 
 TEST(DMEncodeDecodeTest, EDIFACTWithEOD)

--- a/test/unit/datamatrix/DMEncodeDecodeTest.cpp
+++ b/test/unit/datamatrix/DMEncodeDecodeTest.cpp
@@ -121,6 +121,7 @@ TEST(DMEncodeDecodeTest, EncodeDecodeRectangle)
 
 TEST(DMEncodeDecodeTest, EDIFACTWithEOD)
 {
+	TestEncodeDecode(L"https://test~[******]_");
 	TestEncodeDecode(L"abc<->ABCDE");
 }
 


### PR DESCRIPTION
Found another two bugs in the DMHighLevelEncoder. One introduced during the c++ port, the other one likely still in upstream.

Introduced Inflate/Deflate functions for the common use case of scaling/subsampling a bit matrix (duplicate code removal).

Also removed lots of verbose/duplicated code in the DM bit placement / bit parsing code. It seems those two sides of the same coin (generating the DM bit pattern during encoding and parsing it during decoding) have been implemented independently and shared lots of the same patterns.