### PR TITLE
Limit Android workarounds to GCC

### DIFF
--- a/core/src/ZXStrConvWorkaround.h
+++ b/core/src/ZXStrConvWorkaround.h
@@ -14,7 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#if defined(__ANDROID__) && defined(__GNUC__)
+#if defined(__ANDROID__) && defined(__GNUC__) && !defined(__clang__)
 
 #include <sstream>
 #include <cstdlib>


### PR DESCRIPTION
Clang also defines __GNUC__ and thus enables these workarounds too, which
break the build there (ambiguity on std::stoi).