### PR TITLE
Allow to build from the top-level folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(core)


### PR DESCRIPTION
This simplifies usage with packaging or build automation systems, in
particular I ran into this with Flatpak.

This isn't particularly elegant, but it does have the advantage that the
current sub-folder builds are entirely unaffected.