### PR TITLE
Also set the minimum CMake version in the top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,2 @@
+cmake_minimum_required (VERSION 3.1.3)
 add_subdirectory(core)


### PR DESCRIPTION
This is needed when cross-compiling with a toolchain file that sets the
CMP0000 policy to NEW and thus forces cmake_minimum_required() to be the
very first command.