### PR TITLE
Fixes #70 and fixes #71; shared library with version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set (ZXING_VERSION_PATCH 5)
 
 project (ZXingCpp VERSION ${ZXING_VERSION_MAJOR}.${ZXING_VERSION_MINOR}.${ZXING_VERSION_PATCH})
 
-set (ENABLE_ENCODERS OFF CACHE BOOL "Check to include encoders")
+set (ENABLE_ENCODERS ON CACHE BOOL "Check to include encoders")
 set (ENABLE_DECODERS ON CACHE BOOL "Check to include decoders")
 set (LINK_CPP_STATICALLY OFF CACHE BOOL "MSVC only, check to link statically standard library (/MT and /MTd)")
 set (BUILD_SHARED_LIBRARY OFF CACHE BOOL "Check to build ZXingCore as shared library")
@@ -40,7 +40,7 @@ add_subdirectory (core)
 set_target_properties (ZXingCore PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties (ZXingCore PROPERTIES SOVERSION ${ZXING_VERSION_MAJOR})
 
-set (CMAKECONFIG_INSTALL_DIR "lib/cmake/ZXing")
+set (CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/ZXing")
 
 install (
     EXPORT ZXingTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,77 @@
 cmake_minimum_required (VERSION 3.1.3)
-add_subdirectory(core)
+
+set (ZXING_VERSION_MAJOR 1)
+set (ZXING_VERSION_MINOR 0)
+set (ZXING_VERSION_PATCH 5)
+
+project (ZXingCpp VERSION ${ZXING_VERSION_MAJOR}.${ZXING_VERSION_MINOR}.${ZXING_VERSION_PATCH})
+
+set (ENABLE_ENCODERS OFF CACHE BOOL "Check to include encoders")
+set (ENABLE_DECODERS ON CACHE BOOL "Check to include decoders")
+set (LINK_CPP_STATICALLY OFF CACHE BOOL "MSVC only, check to link statically standard library (/MT and /MTd)")
+set (BUILD_SHARED_LIBRARY OFF CACHE BOOL "Check to build ZXingCore as shared library")
+
+add_definitions (-DUNICODE -D_UNICODE)
+
+if (MSVC)
+    set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Oi /GS-")
+    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GS-")
+    if (LINK_CPP_STATICALLY)
+        set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+        set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+        set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+        set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    endif()
+else()
+    set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
+endif()
+
+set (DEFAULT_BUILD_TYPE "Release")
+
+if (NOT CMAKE_BUILD_TYPE)
+	message (STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+	set (CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+    set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+add_subdirectory (core)
+
+set_target_properties (ZXingCore PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties (ZXingCore PROPERTIES SOVERSION ${ZXING_VERSION_MAJOR})
+
+set (CMAKECONFIG_INSTALL_DIR "lib/cmake/ZXing")
+
+install (
+    EXPORT ZXingTargets
+    DESTINATION ${CMAKECONFIG_INSTALL_DIR} NAMESPACE ZXing::
+)
+
+install (
+    DIRECTORY core/src/
+    DESTINATION include/ZXing
+    FILES_MATCHING PATTERN "*.h"
+)
+
+configure_file (
+    core/ZXVersion.h.in
+    ZXVersion.h
+)
+
+install (
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ZXVersion.h"
+    DESTINATION include/ZXing
+)
+
+include (CMakePackageConfigHelpers)
+
+configure_package_config_file (
+    core/ZXingConfig.cmake.in
+    ZXingConfig.cmake
+    INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+)
+
+install (
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfig.cmake"
+    DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,32 +1,5 @@
 cmake_minimum_required (VERSION 3.1.3)
 
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    # this is the top level project
-    project (ZXingCpp)
-    
-    set (ENABLE_ENCODERS OFF CACHE BOOL "Check to include encoders")
-    set (ENABLE_DECODERS ON CACHE BOOL "Check to include decoders")
-    set (LINK_CPP_STATICALLY OFF CACHE BOOL "MSVC only, check to link statically standard library (/MT and /MTd)")
-    set (BUILD_SHARED_LIBRARY OFF CACHE BOOL "Check to build ZXingCore as shared library")
-
-    add_definitions (-DUNICODE -D_UNICODE)
-    
-    if (MSVC)
-        set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Oi /GS-")
-        set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GS-")
-        if (LINK_CPP_STATICALLY)
-            set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
-            set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-            set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
-            set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-        endif()
-    else()
-        set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
-        set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
-    endif()
-    
-endif()
-
 if (NOT DEFINED ENABLE_ENCODERS)
     set (ENABLE_ENCODERS OFF)
 endif()
@@ -473,14 +446,24 @@ target_compile_options (ZXingCore
     PRIVATE ${ZXING_CORE_LOCAL_DEFINES}
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-    target_compile_options (ZXingCore PRIVATE
+include (CheckCXXCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG ("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if (COMPILER_SUPPORTS_CXX11)
+    target_compile_options(ZXingCore PRIVATE
         -std=c++11
+    )
+endif()
+
+CHECK_CXX_COMPILER_FLAG ("-ffloat-store" COMPILER_NEEDS_FLOAT_STORE)
+if (COMPILER_NEEDS_FLOAT_STORE)
+    target_compile_options(ZXingCore PRIVATE
         -ffloat-store   # same floating point precision in all optimization levels
     )
-elseif (APPLE)
+endif()
+
+if (APPLE)
     target_compile_options (ZXingCore PRIVATE
-        -std=c++11
         -stdlib=libc++
     )
 endif()
@@ -490,21 +473,13 @@ target_link_libraries (ZXingCore PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 add_library(ZXing::Core ALIAS ZXingCore)
 set_target_properties(ZXingCore PROPERTIES EXPORT_NAME Core)
 
-set(CMAKECONFIG_INSTALL_DIR "lib/cmake/ZXing")
-install(TARGETS ZXingCore EXPORT ZXingTargets
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
+include (GNUInstallDirs)
+
+# Once we can require cmake 1.13, then we can move this to ../CMakeLists.txt, see: https://gitlab.kitware.com/cmake/cmake/merge_requests/2152
+install (
+    TARGETS ZXingCore EXPORT ZXingTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     INCLUDES DESTINATION include
 )
-install(EXPORT ZXingTargets DESTINATION ${CMAKECONFIG_INSTALL_DIR} NAMESPACE ZXing::)
-
-install(
-    DIRECTORY src/
-    DESTINATION include/ZXing
-    FILES_MATCHING PATTERN "*.h"
-)
-
-include(CMakePackageConfigHelpers)
-configure_package_config_file(ZXingConfig.cmake.in ZXingConfig.cmake INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXingConfig.cmake DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/core/ZXVersion.h.in
+++ b/core/ZXVersion.h.in
@@ -1,0 +1,21 @@
+#pragma once
+/*
+* Copyright 2019 Nu-book Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// Version numbering
+#define ZXING_VERSION_MAJOR @ZXING_VERSION_MAJOR@
+#define ZXING_VERSION_MINOR @ZXING_VERSION_MINOR@
+#define ZXING_VERSION_PATCH @ZXING_VERSION_PATCH@

--- a/core/src/ZXConfig.h
+++ b/core/src/ZXConfig.h
@@ -21,11 +21,6 @@
 
 #define ZX_HAVE_CONFIG
 
-// Version numbering
-#define ZXING_VERSION_MAJOR 1
-#define ZXING_VERSION_MINOR 0
-#define ZXING_VERSION_PATCH 5
-
 #if !__has_attribute(cxx_rtti) && !defined(__RTTI) && !defined(_CPPRTTI) && !defined(__GXX_RTTI) && !defined(__INTEL_RTTI__)
 	#define ZX_NO_RTTI
 #endif


### PR DESCRIPTION
Also:
- Version is now defined in CMakeLists.txt, include/ZXing/XZVersion.h is generated with corresponding numbers.
- Project definition is moved from core/CMakeLists.txt to ./CMakeLists as it's more logical for it to be there.
