### PR TITLE
Update Windows Runtime API to allow Barcode types to be configured

### DIFF
--- a/wrappers/winrt/BarcodeReader.cpp
+++ b/wrappers/winrt/BarcodeReader.cpp
@@ -27,6 +27,7 @@
 #include "MultiFormatReader.h"
 #include "ReadResult.h"
 #include "Result.h"
+#include "TextUtfEncoding.h"
 
 #include <algorithm>
 #include <MemoryBuffer.h>
@@ -41,6 +42,22 @@ namespace ZXing {
 
 BarcodeReader::BarcodeReader(bool tryHarder, bool tryRotate, const Platform::Array<BarcodeType>^ types)
 {
+	init(tryHarder, tryRotate, types);
+}
+
+BarcodeReader::BarcodeReader(bool tryHarder, bool tryRotate)
+{
+	init(tryHarder, tryRotate, nullptr);
+}
+
+BarcodeReader::BarcodeReader(bool tryHarder)
+{
+	init(tryHarder, tryHarder, nullptr);
+}
+
+void
+BarcodeReader::init(bool tryHarder, bool tryRotate, const Platform::Array<BarcodeType>^ types)
+{
 	DecodeHints hints;
 	hints.setShouldTryHarder(tryHarder);
 	hints.setShouldTryRotate(tryRotate);
@@ -53,22 +70,6 @@ BarcodeReader::BarcodeReader(bool tryHarder, bool tryRotate, const Platform::Arr
 		hints.setPossibleFormats(barcodeFormats);
 	}
 
-	m_reader.reset(new MultiFormatReader(hints));
-}
-
-BarcodeReader::BarcodeReader(bool tryHarder, bool tryRotate)
-{
-	DecodeHints hints;
-	hints.setShouldTryHarder(tryHarder);
-	hints.setShouldTryRotate(tryRotate);
-	m_reader.reset(new MultiFormatReader(hints));
-}
-
-BarcodeReader::BarcodeReader(bool tryHarder)
-{
-	DecodeHints hints;
-	hints.setShouldTryHarder(tryHarder);
-	hints.setShouldTryRotate(tryHarder);
 	m_reader.reset(new MultiFormatReader(hints));
 }
 
@@ -115,8 +116,7 @@ BarcodeFormat BarcodeReader::ConvertRuntimeToNative(BarcodeType type)
 		return BarcodeFormat::UPC_EAN_EXTENSION;
 	default:
 		std::wstring typeAsString = type.ToString()->Begin();
-		throw std::invalid_argument("Unknown Barcode Type: "
-			+ std::string( typeAsString.begin(), typeAsString.end()));
+		throw std::invalid_argument("Unknown Barcode Type: " + TextUtfEncoding::ToUtf8(typeAsString));
 	}
 }
 

--- a/wrappers/winrt/BarcodeReader.cpp
+++ b/wrappers/winrt/BarcodeReader.cpp
@@ -115,8 +115,50 @@ BarcodeFormat BarcodeReader::ConvertRuntimeToNative(BarcodeType type)
 		return BarcodeFormat::UPC_EAN_EXTENSION;
 	default:
 		std::wstring typeAsString = type.ToString()->Begin();
-		throw std::invalid_argument("Unknown Barcode Format: "
+		throw std::invalid_argument("Unknown Barcode Type: "
 			+ std::string( typeAsString.begin(), typeAsString.end()));
+	}
+}
+
+BarcodeType BarcodeReader::ConvertNativeToRuntime(BarcodeFormat format)
+{
+	switch (format) {
+	case BarcodeFormat::AZTEC:
+		return BarcodeType::AZTEC;
+	case BarcodeFormat::CODABAR:
+		return BarcodeType::CODABAR;
+	case BarcodeFormat::CODE_128:
+		return BarcodeType::CODE_128;
+	case BarcodeFormat::CODE_39:
+		return BarcodeType::CODE_39;
+	case BarcodeFormat::CODE_93:
+		return BarcodeType::CODE_93;
+	case BarcodeFormat::DATA_MATRIX:
+		return BarcodeType::DATA_MATRIX;
+	case BarcodeFormat::EAN_13:
+		return BarcodeType::EAN_13;
+	case BarcodeFormat::EAN_8:
+		return BarcodeType::EAN_8;
+	case BarcodeFormat::ITF:
+		return BarcodeType::ITF;
+	case BarcodeFormat::MAXICODE:
+		return BarcodeType::MAXICODE;
+	case BarcodeFormat::PDF_417:
+		return BarcodeType::PDF_417;
+	case BarcodeFormat::QR_CODE:
+		return BarcodeType::QR_CODE;
+	case BarcodeFormat::RSS_14:
+		return BarcodeType::RSS_14;
+	case BarcodeFormat::RSS_EXPANDED:
+		return BarcodeType::RSS_EXPANDED;
+	case BarcodeFormat::UPC_A:
+		return BarcodeType::UPC_A;
+	case BarcodeFormat::UPC_E:
+		return BarcodeType::UPC_E;
+	case BarcodeFormat::UPC_EAN_EXTENSION:
+		return BarcodeType::UPC_EAN_EXTENSION;
+	default:
+		throw std::invalid_argument("Unknown Barcode Format ");
 	}
 }
 
@@ -178,7 +220,7 @@ BarcodeReader::Read(SoftwareBitmap^ bitmap, int cropWidth, int cropHeight)
 		auto binImg = CreateBinaryBitmap(bitmap, cropWidth, cropHeight);
 		auto result = m_reader->read(*binImg);
 		if (result.isValid()) {
-			return ref new ReadResult(ToPlatformString(ZXing::ToString(result.format())), ToPlatformString(result.text()));
+			return ref new ReadResult(ToPlatformString(ZXing::ToString(result.format())), ToPlatformString(result.text()), ConvertNativeToRuntime(result.format()));
 		}
 	}
 	catch (const std::exception& e) {

--- a/wrappers/winrt/BarcodeReader.h
+++ b/wrappers/winrt/BarcodeReader.h
@@ -53,6 +53,8 @@ public:
 private:
 	~BarcodeReader();
 
+	void init(bool tryHarder, bool tryRotate, const Platform::Array<BarcodeType>^ types);
+
 	static BarcodeFormat ConvertRuntimeToNative(BarcodeType type);
 	static BarcodeType ConvertNativeToRuntime(BarcodeFormat format);
 

--- a/wrappers/winrt/BarcodeReader.h
+++ b/wrappers/winrt/BarcodeReader.h
@@ -15,7 +15,6 @@
 * limitations under the License.
 */
 #include "BarcodeFormat.h"
-#include "ReadResult.h"
 
 namespace ZXing {
 
@@ -36,8 +35,7 @@ public enum class BarcodeType : int {
 	RSS_EXPANDED,
 	UPC_A,
 	UPC_E,
-	UPC_EAN_EXTENSION,
-	FORMAT_COUNT,
+	UPC_EAN_EXTENSION
 };
 
 class MultiFormatReader;
@@ -56,6 +54,7 @@ private:
 	~BarcodeReader();
 
 	static BarcodeFormat ConvertRuntimeToNative(BarcodeType type);
+	static BarcodeType ConvertNativeToRuntime(BarcodeFormat format);
 
 	std::unique_ptr<MultiFormatReader> m_reader;
 };

--- a/wrappers/winrt/BarcodeReader.h
+++ b/wrappers/winrt/BarcodeReader.h
@@ -14,10 +14,31 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-#include <memory>
+#include "BarcodeFormat.h"
+#include "ReadResult.h"
 
 namespace ZXing {
+
+public enum class BarcodeType : int {
+	AZTEC,
+	CODABAR,
+	CODE_39,
+	CODE_93,
+	CODE_128,
+	DATA_MATRIX,
+	EAN_8,
+	EAN_13,
+	ITF,
+	MAXICODE,
+	PDF_417,
+	QR_CODE,
+	RSS_14,
+	RSS_EXPANDED,
+	UPC_A,
+	UPC_E,
+	UPC_EAN_EXTENSION,
+	FORMAT_COUNT,
+};
 
 class MultiFormatReader;
 ref class ReadResult;
@@ -25,12 +46,16 @@ ref class ReadResult;
 public ref class BarcodeReader sealed
 {
 public:
+	BarcodeReader(bool tryHarder, bool tryRotate, const Platform::Array<BarcodeType>^ types);
+	BarcodeReader(bool tryHarder, bool tryRotate);
 	BarcodeReader(bool tryHarder);
 
 	ReadResult^ Read(Windows::Graphics::Imaging::SoftwareBitmap^ bitmap, int cropWidth, int cropHeight);
 
 private:
 	~BarcodeReader();
+
+	static BarcodeFormat ConvertRuntimeToNative(BarcodeType type);
 
 	std::unique_ptr<MultiFormatReader> m_reader;
 };

--- a/wrappers/winrt/ReadResult.h
+++ b/wrappers/winrt/ReadResult.h
@@ -32,12 +32,20 @@ public:
 		}
 	}
 
+	property BarcodeType Type {
+		BarcodeType get() {
+			return m_barcode_type;
+		}
+	}
+
 internal:
-	ReadResult(Platform::String^ format, Platform::String^ text) : m_format(format), m_text(text) {}
+	ReadResult(Platform::String^ format, Platform::String^ text, BarcodeType type) : m_format(format), m_text(text), m_barcode_type(type) {}
 
 private:
 	Platform::String^ m_format;
 	Platform::String^ m_text;
+
+	BarcodeType m_barcode_type;
 };
 
 } // ZXing


### PR DESCRIPTION
This pull request addresses issue #74 

It breaks out the rotation and tryHarder settings and adds the ability to pass an array of barcode types.

It also adds an enumeration to the result object.
