### PR TITLE
get qr location point data

### DIFF
--- a/core/src/MultiFormatReader.cpp
+++ b/core/src/MultiFormatReader.cpp
@@ -101,8 +101,11 @@ MultiFormatReader::read(const BinaryBitmap& image) const
 {
 	for (const auto& reader : _readers) {
 		Result r = reader->decode(image);
-  		if (r.isValid())
+  		if (r.isValid()){
 			return r;
+  		}else if (r.isBlurry()){
+			return r;
+  		}
 	}
 	return Result(DecodeStatus::NotFound);
 }

--- a/core/src/Result.h
+++ b/core/src/Result.h
@@ -48,6 +48,10 @@ public:
 		return StatusIsOK(_status);
 	}
 
+	bool isBlurry() const {
+		return resultPoints().size() > 2;
+	}
+
 	DecodeStatus status() const {
 		return _status;
 	}

--- a/core/src/qrcode/QRReader.cpp
+++ b/core/src/qrcode/QRReader.cpp
@@ -166,6 +166,10 @@ Reader::decode(const BinaryBitmap& image) const
 		points = detectorResult.points();
 	}
 
+	if (points.size() > 2){
+		return Result(std::move(decoderResult), std::move(points), BarcodeFormat::QR_CODE);
+	}
+
 	if (!decoderResult.isValid()) {
 		return Result(decoderResult.errorCode());
 	}


### PR DESCRIPTION
When i use zxing in android, i need to zoom in the camera automatic when i was far from the qrcode image, but i found If i get the points data ,i got the qrcode text too, so i add the points location data method, even the decoder did'nt get the result text ,but i can control my camera by this points.