### PR TITLE
fix thread-safety regression in RSS* decoders

### DIFF
--- a/core/src/oned/ODRSS14Reader.cpp
+++ b/core/src/oned/ODRSS14Reader.cpp
@@ -403,19 +403,20 @@ ConstructResult(const RSS::Pair& leftPair, const RSS::Pair& rightPair)
 Result
 RSS14Reader::decodeRow(int rowNumber, const BitArray& row_) const
 {
+	auto& possiblePairs = state();
 	BitArray row = row_.copy();
-	AddOrTally(possibleLeftPairs, DecodePair(row, false, rowNumber));
+	AddOrTally(possiblePairs.left, DecodePair(row, false, rowNumber));
 	row.reverse();
-	AddOrTally(possibleRightPairs, DecodePair(row, true, rowNumber));
+	AddOrTally(possiblePairs.right, DecodePair(row, true, rowNumber));
 //	row.reverse();
 
 	// To be able to detect "stacked" RSS codes (split over multiple lines)
 	// we need to store the parts we found and try all possible left/right
 	// combinations. To prevent lots of false positives, we require each
 	// pair to have been seen in at least two lines.
-	for (const auto& left : possibleLeftPairs) {
+	for (const auto& left : possiblePairs.left) {
 		if (left.count() > 1) {
-			for (const auto& right : possibleRightPairs) {
+			for (const auto& right : possiblePairs.right) {
 				if (right.count() > 1) {
 					if (CheckChecksum(left, right)) {
 						return ConstructResult(left, right);

--- a/core/src/oned/ODRSS14Reader.h
+++ b/core/src/oned/ODRSS14Reader.h
@@ -29,15 +29,20 @@ namespace OneD {
 */
 class RSS14Reader : public RowReader
 {
-	mutable std::vector<RSS::Pair> possibleLeftPairs;
-	mutable std::vector<RSS::Pair> possibleRightPairs;
+	struct State
+	{
+		std::vector<RSS::Pair> left, right;
+	};
+
+	mutable ThreadLocal<State> state;
 
 public:
 	Result decodeRow(int rowNumber, const BitArray& row) const override;
 
 	void reset() override {
-		possibleLeftPairs.clear();
-		possibleRightPairs.clear();
+		auto& possiblePairs = state();
+		possiblePairs.left.clear();
+		possiblePairs.right.clear();
 	}
 };
 

--- a/core/src/oned/ODRSSExpandedReader.cpp
+++ b/core/src/oned/ODRSSExpandedReader.cpp
@@ -707,6 +707,7 @@ RSSExpandedReader::decodeRow(int rowNumber, const BitArray& row) const
 {
 	// Rows can start with even pattern in case in prev rows there where odd number of patters.
 	// So lets try twice
+	auto& rows = this->rows();
 	Result r = ConstructResult(DecodeRow2Pairs(rowNumber, row, false, rows));
 	if (!r.isValid()) {
 		r = ConstructResult(DecodeRow2Pairs(rowNumber, row, true, rows));

--- a/core/src/oned/ODRSSExpandedReader.h
+++ b/core/src/oned/ODRSSExpandedReader.h
@@ -30,13 +30,13 @@ namespace OneD {
 */
 class RSSExpandedReader : public RowReader
 {
-	mutable std::list<RSS::ExpandedRow> rows;
+	mutable ThreadLocal<std::list<RSS::ExpandedRow>> rows;
 
 public:
 	Result decodeRow(int rowNumber, const BitArray& row) const override;
 
 	void reset() override {
-		rows.clear();
+		rows().clear();
 	}
 };
 

--- a/core/src/oned/ODRowReader.h
+++ b/core/src/oned/ODRowReader.h
@@ -22,6 +22,10 @@
 #include <cstddef>
 #include <memory>
 
+#include <thread>
+#include <mutex>
+#include <map>
+
 namespace ZXing {
 
 class Result;
@@ -37,12 +41,29 @@ namespace OneD {
 */
 class RowReader
 {
+protected:
+	/**
+	 * @brief Helper template for thread local type storage for per image state data of multi-line "1D" readers (like RSS)
+	 */
+	template<typename T>
+	class ThreadLocal
+	{
+		std::map<std::thread::id, T> store;
+		std::mutex mut;
+	public:
+		T& operator()()
+		{
+			std::lock_guard<std::mutex> lock(mut);
+			return store[std::this_thread::get_id()];
+		}
+	};
+
 public:
 
 	virtual ~RowReader() {}
 
 	/**
-	 * @brief resets the internal state which some readers have to be able to decode multi-line variantes (e.g. RSS).
+	 * @brief resets the internal state which some readers have to be able to decode multi-line variants (e.g. RSS).
 	 *
 	 * Call before starting to process a new image.
 	 */


### PR DESCRIPTION
Introduce little ThreadLocal template helper to implement some kind of 'thread local storage' for the RSS-type readers that support 'stacked' 1D codes (i.e. 2D codes actually) and need to store some state between decoding different lines.

This is a fix for the thread-safety regression introduced in 17284ea7775d9a4da034a3f817320fbb10813de0