### PR TITLE
Remove dynamic cast

### DIFF
--- a/core/src/ZXConfig.h
+++ b/core/src/ZXConfig.h
@@ -21,10 +21,6 @@
 
 #define ZX_HAVE_CONFIG
 
-#if !__has_attribute(cxx_rtti) && !defined(__RTTI) && !defined(_CPPRTTI) && !defined(__GXX_RTTI) && !defined(__INTEL_RTTI__)
-	#define ZX_NO_RTTI
-#endif
-
 // Thread local or static memory may be used to reduce the number of (re-)allocations of temporary variables
 // in e.g. the ReedSolomonDecoder. It is disabled by default. It can be enabled by modifying the following define.
 // Note: The Apple clang compiler until XCode 8 does not support c++11's thread_local.

--- a/core/src/oned/ODRSS14Reader.cpp
+++ b/core/src/oned/ODRSS14Reader.cpp
@@ -418,23 +418,10 @@ ConstructResult(const RSS::Pair& leftPair, const RSS::Pair& rightPair)
 Result
 RSS14Reader::decodeRow(int rowNumber, const BitArray& row_, std::unique_ptr<DecodingState>& state) const
 {
-	RSS14DecodingState* prevState = nullptr;
-	if (state == nullptr) {
-		state.reset(prevState = new RSS14DecodingState);
+	if (!state) {
+		state.reset(new RSS14DecodingState);
 	}
-	else {
-#if !defined(ZX_HAVE_CONFIG)
-		#error "You need to include ZXConfig.h"
-#elif !defined(ZX_NO_RTTI)
-		prevState = dynamic_cast<RSS14DecodingState*>(state.get());
-#else
-		prevState = static_cast<RSS14DecodingState*>(state.get());
-#endif
-	}
-
-	if (prevState == nullptr) {
-		throw std::runtime_error("Invalid state");
-	}
+	auto* prevState = static_cast<RSS14DecodingState*>(state.get());
 
 	BitArray row = row_.copy();
 	AddOrTally(prevState->possibleLeftPairs, DecodePair(row, false, rowNumber));

--- a/core/src/oned/ODRSSExpandedReader.cpp
+++ b/core/src/oned/ODRSSExpandedReader.cpp
@@ -712,23 +712,10 @@ ConstructResult(const std::list<ExpandedPair>& pairs)
 Result
 RSSExpandedReader::decodeRow(int rowNumber, const BitArray& row, std::unique_ptr<DecodingState>& state) const
 {
-	RSSExpandedDecodingState* prevState = nullptr;
-	if (state == nullptr) {
-		state.reset(prevState = new RSSExpandedDecodingState);
+	if (!state) {
+		state.reset(new RSSExpandedDecodingState);
 	}
-	else {
-#if !defined(ZX_HAVE_CONFIG)
-		#error "You need to include ZXConfig.h"
-#elif !defined(ZX_NO_RTTI)
-		prevState = dynamic_cast<RSSExpandedDecodingState*>(state.get());
-#else
-		prevState = static_cast<RSSExpandedDecodingState*>(state.get());
-#endif
-	}
-
-	if (prevState == nullptr) {
-		throw std::runtime_error("Invalid state");
-	}
+	auto* prevState = static_cast<RSSExpandedDecodingState*>(state.get());
 
 	// Rows can start with even pattern in case in prev rows there where odd number of patters.
 	// So lets try twice

--- a/test/unit/oned/ODCode128WriterTest.cpp
+++ b/test/unit/oned/ODCode128WriterTest.cpp
@@ -49,8 +49,7 @@ static ZXing::Result Decode(const BitMatrix &matrix)
 {
 	BitArray row;
 	matrix.getRow(0, row);
-	std::unique_ptr<RowReader::DecodingState> state;
-	return Code128Reader(DecodeHints()).decodeRow(0, row, state);
+	return Code128Reader(DecodeHints()).decodeSingleRow(0, row);
 }
 
 TEST(ODCode128Writer, EncodeWithFunc1)


### PR DESCRIPTION
Here is the remove-dynamic-cast part from my recently reverted remove-external-state changeset. There is a theoretical argument to make that this does not detect a potential programming error during runtime, which the old code did (if RTTI was enabled). Using RTTI to detect program defects is not the way the go though, IMHO.