### PR TITLE
issue #99 - avoid referencing past the end element of a vector

### DIFF
--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -299,9 +299,7 @@ public:
 	*/
 #ifdef ZX_FAST_BIT_STORAGE
 	bool isRange(int start, int end, bool value) const {
-        auto start_it = std::cbegin(_bits) + start;
-        auto end_it = std::cbegin(_bits) + end;
-        return std::all_of(start_it, end_it, [value](uint8_t v) { return v == static_cast<int>(value); });
+        return std::all_of(std::begin(_bits) + start, std::cbegin(_bits) + end, [value](uint8_t v) { return v == static_cast<int>(value); });
 	}
 #else
 	bool isRange(int start, int end, bool value) const;

--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -299,7 +299,7 @@ public:
 	*/
 #ifdef ZX_FAST_BIT_STORAGE
 	bool isRange(int start, int end, bool value) const {
-        return std::all_of(std::begin(_bits) + start, std::begin(_bits) + end, [value](uint8_t v) { return v == static_cast<int>(value); });
+		return std::all_of(std::begin(_bits) + start, std::begin(_bits) + end, [value](uint8_t v) { return v == static_cast<int>(value); });
 	}
 #else
 	bool isRange(int start, int end, bool value) const;

--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -299,7 +299,8 @@ public:
 	*/
 #ifdef ZX_FAST_BIT_STORAGE
 	bool isRange(int start, int end, bool value) const {
-		return std::all_of(&_bits[start], &_bits[end], [value](uint8_t v) { return v == static_cast<int>(value); });
+        auto iterator = cbegin(_bits);
+        return std::all_of((advance(iterator, start), iterator), (advance(iterator, end - start), iterator), [value](uint8_t v) { return v == static_cast<int>(value); });
 	}
 #else
 	bool isRange(int start, int end, bool value) const;

--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -299,7 +299,7 @@ public:
 	*/
 #ifdef ZX_FAST_BIT_STORAGE
 	bool isRange(int start, int end, bool value) const {
-        return std::all_of(std::begin(_bits) + start, std::cbegin(_bits) + end, [value](uint8_t v) { return v == static_cast<int>(value); });
+        return std::all_of(std::begin(_bits) + start, std::begin(_bits) + end, [value](uint8_t v) { return v == static_cast<int>(value); });
 	}
 #else
 	bool isRange(int start, int end, bool value) const;

--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -299,8 +299,9 @@ public:
 	*/
 #ifdef ZX_FAST_BIT_STORAGE
 	bool isRange(int start, int end, bool value) const {
-        auto iterator = cbegin(_bits);
-        return std::all_of((advance(iterator, start), iterator), (advance(iterator, end - start), iterator), [value](uint8_t v) { return v == static_cast<int>(value); });
+        auto start_it = std::cbegin(_bits) + start;
+        auto end_it = std::cbegin(_bits) + end;
+        return std::all_of(start_it, end_it, [value](uint8_t v) { return v == static_cast<int>(value); });
 	}
 #else
 	bool isRange(int start, int end, bool value) const;


### PR DESCRIPTION
issue #99 - avoid referencing past the end element of a vector; when parameter `end` equals `_bits.size()` then `_bits[end]` references a past-the-end element which triggers a debug assertion in MSVC, even if `&_bits[end]` is absolutely legal and safe