### PR TITLE
add missing <stdexcept> headers for msvc 14.26

### DIFF
--- a/core/src/MultiFormatWriter.cpp
+++ b/core/src/MultiFormatWriter.cpp
@@ -14,6 +14,8 @@
 * limitations under the License.
 */
 
+#include <stdexcept>
+
 #include "MultiFormatWriter.h"
 #include "BitMatrix.h"
 #include "aztec/AZWriter.h"

--- a/core/src/ReedSolomonEncoder.cpp
+++ b/core/src/ReedSolomonEncoder.cpp
@@ -18,6 +18,8 @@
 #include "ReedSolomonEncoder.h"
 #include "GenericGF.h"
 
+#include <stdexcept>
+
 namespace ZXing {
 
 ReedSolomonEncoder::ReedSolomonEncoder(const GenericGF& field)

--- a/core/src/aztec/AZEncoder.cpp
+++ b/core/src/aztec/AZEncoder.cpp
@@ -24,6 +24,7 @@
 #include "ZXTestSupport.h"
 
 #include <cstdlib>
+#include <stdexcept>
 
 namespace ZXing {
 namespace Aztec {

--- a/core/src/oned/ODUPCEANCommon.h
+++ b/core/src/oned/ODUPCEANCommon.h
@@ -18,6 +18,7 @@
 #include "ODUPCEANReader.h"
 
 #include <array>
+#include <stdexcept>
 
 namespace ZXing {
 namespace OneD {

--- a/core/src/pdf417/PDFDetectionResultColumn.cpp
+++ b/core/src/pdf417/PDFDetectionResultColumn.cpp
@@ -19,6 +19,7 @@
 #include "PDFBarcodeMetadata.h"
 #include "PDFBarcodeValue.h"
 #include <algorithm>
+#include <stdexcept>
 
 namespace ZXing {
 namespace Pdf417 {

--- a/core/src/pdf417/PDFHighLevelEncoder.cpp
+++ b/core/src/pdf417/PDFHighLevelEncoder.cpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <array>
 #include <algorithm>
+#include <stdexcept>
 
 namespace ZXing {
 namespace Pdf417 {

--- a/core/src/pdf417/PDFModulusGF.cpp
+++ b/core/src/pdf417/PDFModulusGF.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "PDFModulusGF.h"
+#include <stdexcept>
 
 namespace ZXing {
 namespace Pdf417 {

--- a/core/src/pdf417/PDFModulusPoly.cpp
+++ b/core/src/pdf417/PDFModulusPoly.cpp
@@ -19,6 +19,7 @@
 #include "PDFModulusGF.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 namespace ZXing {
 namespace Pdf417 {

--- a/core/src/qrcode/QREncoder.cpp
+++ b/core/src/qrcode/QREncoder.cpp
@@ -30,6 +30,7 @@
 #include "ZXTestSupport.h"
 
 #include <array>
+#include <stdexcept>
 
 namespace ZXing {
 namespace QRCode {

--- a/core/src/qrcode/QRMatrixUtil.cpp
+++ b/core/src/qrcode/QRMatrixUtil.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <string>
+#include <stdexcept>
 
 namespace ZXing {
 namespace QRCode {

--- a/core/src/qrcode/QRVersion.cpp
+++ b/core/src/qrcode/QRVersion.cpp
@@ -21,6 +21,7 @@
 #include "BitMatrix.h"
 
 #include <limits>
+#include <stdexcept>
 
 namespace ZXing {
 namespace QRCode {

--- a/example/generate_image.cpp
+++ b/example/generate_image.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <stdexcept>
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"

--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <memory>
+#include <stdexcept>
 #include <emscripten/bind.h>
 
 #define STB_IMAGE_IMPLEMENTATION

--- a/wrappers/wasm/BarcodeWriter.cpp
+++ b/wrappers/wasm/BarcodeWriter.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <memory>
+#include <stdexcept>
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 


### PR DESCRIPTION
compilation breaks when upgrading msvc from 14.25 to 14.26.
this pull request fixes it.

note: please squash