### PR TITLE
Fix Android build

### DIFF
--- a/core/src/ZXNumeric.h
+++ b/core/src/ZXNumeric.h
@@ -83,11 +83,7 @@ template <typename T>
 typename std::enable_if<std::is_floating_point<T>::value, int>::type
 RoundToNearest(T x)
 {
-#if defined(__ANDROID__) && defined(__GNUC__)
-	return static_cast<int>(round(x));
-#else
 	return static_cast<int>(std::round(x));
-#endif
 }
 
 /// <summary>

--- a/core/src/datamatrix/DMDetector.cpp
+++ b/core/src/datamatrix/DMDetector.cpp
@@ -118,11 +118,7 @@ inline static bool IsValidPoint(const ResultPoint& p, int imgWidth, int imgHeigh
 
 inline static float RoundToNearest(float x)
 {
-#if defined(__ANDROID__) && defined(__GNUC__)
-	return static_cast<float>(round(x));
-#else
 	return std::round(x);
-#endif
 }
 
 /**


### PR DESCRIPTION
The recent changes in Point.h made the unqualified round() call ambiguous
here, but since Android nowadays does have std::round we can fix this and
simplify the code at the same time.