### PR TITLE
Support for CMake package versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
 
-project (ZXing VERSION "1.0.8" LANGUAGES CXX)
+set(ZXing_VERSION 1.0.8)
+project (ZXing VERSION ${ZXing_VERSION} LANGUAGES CXX)
 
 option (BUILD_WRITERS "Build with writer support (encoders)" ON)
 option (BUILD_READERS "Build with reader support (decoders)" ON)
@@ -106,6 +107,12 @@ ENDIF()
 
 include (CMakePackageConfigHelpers)
 
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfigVersion.cmake"
+    VERSION ${ZXing_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
 configure_package_config_file (
     core/ZXingConfig.cmake.in
     ZXingConfig.cmake
@@ -113,6 +120,8 @@ configure_package_config_file (
 )
 
 install (
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfig.cmake"
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfigVersion.cmake"
     DESTINATION ${CMAKECONFIG_INSTALL_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required (VERSION 3.10)
 
-set(ZXing_VERSION 1.0.8)
-project (ZXing VERSION ${ZXing_VERSION} LANGUAGES CXX)
+project (ZXing VERSION "1.0.8" LANGUAGES CXX)
 
 option (BUILD_WRITERS "Build with writer support (encoders)" ON)
 option (BUILD_READERS "Build with reader support (decoders)" ON)
@@ -109,7 +108,7 @@ include (CMakePackageConfigHelpers)
 
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/ZXingConfigVersion.cmake"
-    VERSION ${ZXing_VERSION}
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 


### PR DESCRIPTION
This provides basic CMake package versioning support so that `find_package(ZXing 1.0.8 REQUIRED)` becomes possible. Follows the official example from the CMake manual ([cmake-packages(7) section 'Creating Packages'](https://cmake.org/cmake/help/v3.6/manual/cmake-packages.7.html#creating-packages)).

I [have read](https://github.com/swex/QZXingNu/issues/6#issuecomment-648652033) you'd welcome a PR for this :slightly_smiling_face: Tried to figure it out and it seems to work. I don't know much CMake though, so take with a grain of salt …


## Test results

All tests done with ZXing-C++ 1.0.8 @ d66c849 (2020-06-23).


### Without the patch

* **In a client project using `find_package(ZXing REQUIRED)`:** `cmake ..` runs successfully.

* **In a client project using `find_package(ZXing 1.0.8 REQUIRED)`:** `cmake ..` fails with:

     ```
    CMake Warning at CMakeLists.txt:171 (find_package): 
       Could not find a configuration file for package "ZXing" that is compatible 
       with requested version "1.0.8". 
       The following configuration files were considered but not accepted:
         /usr/local/lib/cmake/ZXing/ZXingConfig.cmake, version: unknown
    ```


### With the patch

* **In a client project using `find_package(ZXing REQUIRED)`:** `cmake ..` runs successfully.

* **In a client project using `find_package(ZXing 1.0.7 REQUIRED)`:** `cmake ..` runs successfully.

* **In a client project using `find_package(ZXing 1.0.8 REQUIRED)`:** `cmake ..` runs successfully.

* **In a client project using `find_package(ZXing 1.0.9 REQUIRED)`:** `cmake ..` fails with:

    ```
    CMake Error at CMakeLists.txt:172 (find_package): 
      Could not find a configuration file for package "ZXing" that is compatible 
      with requested version "1.0.9". 
      The following configuration files were considered but not accepted:
        /usr/local/lib/cmake/ZXing/ZXingConfig.cmake, version: 1.0.8
    ```