### PR TITLE
Fix include syntax

### DIFF
--- a/core/src/BitArray.h
+++ b/core/src/BitArray.h
@@ -18,6 +18,7 @@
 */
 
 #include "ZXConfig.h"
+#include "ZXContainerAlgorithms.h"
 #ifndef ZX_FAST_BIT_STORAGE
 #include "BitHacks.h"
 #endif
@@ -27,7 +28,6 @@
 #include <vector>
 #include <algorithm>
 #include <utility>
-#include <ZXContainerAlgorithms.h>
 
 namespace ZXing {
 

--- a/core/src/DecodeStatus.h
+++ b/core/src/DecodeStatus.h
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 
-#include <ZXConfig.h>
+#include "ZXConfig.h"
 
 namespace ZXing {
 

--- a/core/src/GenericGFPoly.h
+++ b/core/src/GenericGFPoly.h
@@ -16,11 +16,12 @@
 * limitations under the License.
 */
 
+#include "ZXContainerAlgorithms.h"
+
 #include <algorithm>
 #include <cstddef>
 #include <cassert>
 #include <vector>
-#include <ZXContainerAlgorithms.h>
 
 namespace ZXing {
 


### PR DESCRIPTION
Recent changes broke the build downstream.
```
In file included from […]/src/kitinerary/src/qimagepurebinarizer.cpp:10:
[…]/include/ZXing/BitArray.h:30:10: error: 'ZXContainerAlgorithms.h' file not found with <angled> include; use "quotes" instead
#include <ZXContainerAlgorithms.h>
         ^
```