### PR TITLE
PDFCodewordDecoder.cpp: uint16_t requires cstdint

### DIFF
--- a/core/src/pdf417/PDFCodewordDecoder.cpp
+++ b/core/src/pdf417/PDFCodewordDecoder.cpp
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <algorithm>
+#include <cstdint>
 #include <numeric>
 #include <limits>
 


### PR DESCRIPTION
cmake version 3.17.3, gcc (GCC) 10.1.0, Arch Linux 5.7.7-arch1-1:

```
[1/51] Building CXX object core/CMakeFiles/ZXing.dir/src/pdf417/PDFCodewordDecoder.cpp.o
FAILED: core/CMakeFiles/ZXing.dir/src/pdf417/PDFCodewordDecoder.cpp.o 
ccache /usr/bin/c++  -DZXing_EXPORTS -I../core/src -fPIC   -Wall -Wextra -Wno-missing-braces -ffloat-store -std=c++14 -MD -MT core/CMakeFiles/ZXing.dir/src/pdf417/PDFCodewordDecoder.cpp.o -MF core/CMakeFiles/ZXing.dir/src/pdf417/PDFCodewordDecoder.cpp.o.d -o core/CMakeFiles/ZXing.dir/src/pdf417/PDFCodewordDecoder.cpp.o -c ../core/src/pdf417/PDFCodewordDecoder.cpp
../core/src/pdf417/PDFCodewordDecoder.cpp:275:25: error: ‘uint16_t’ was not declared in this scope; did you mean ‘u_int16_t’?
  275 | static const std::array<uint16_t, 2787> CODEWORD_TABLE = {
      |                         ^~~~~~~~
      |                         u_int16_t
../core/src/pdf417/PDFCodewordDecoder.cpp:275:39: error: template argument 1 is invalid
  275 | static const std::array<uint16_t, 2787> CODEWORD_TABLE = {
      |                                       ^
../core/src/pdf417/PDFCodewordDecoder.cpp:275:41: error: scalar object ‘ZXing::Pdf417::CODEWORD_TABLE’ requires one element in initializer
  275 | static const std::array<uint16_t, 2787> CODEWORD_TABLE = {
      |                                         ^~~~~~~~~~~~~~
[6/51] Building CXX object core/CMakeFiles/ZXing.dir/src/pdf417/PDFScanningDecoder.cpp.o
ninja: build stopped: subcommand failed.
```