### PR TITLE
Fix debug build on Android

### DIFF
--- a/core/src/LogMatrix.h
+++ b/core/src/LogMatrix.h
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <string>
 
 namespace ZXing {
 


### PR DESCRIPTION
LogMatrix.h:89:14: error: implicit instantiation of undefined template
'std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>,
 std::__ndk1::allocator<char>>'

See https://binary-factory.kde.org/view/Android/job/Itinerary_android/861/console for full build log.