### PR TITLE
fixed wrong pkgconfig file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ if (NOT DEFINED INSTALLDIR)
 endif()
 
 IF (NOT WIN32)
+    set(TARGET_ZXING ${PROJECT_NAME})
     configure_file(zxing.pc.in zxing.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zxing.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 ENDIF()


### PR DESCRIPTION
Added `set(TARGET_ZXING ${PROJECT_NAME})` in CMakeLists.txt

On ArchLinux, `zxing-cpp` version 1.1.0-1
```
> cat /usr/lib/pkgconfig/zxing.pc
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: ZXing
Description: ZXing library set
Version:
Libs: -L${libdir} -l
Cflags: -I${includedir} -I${includedir}/ZXing
```

Where `Libs` should contain a `-lZXing`
This has caused `Qv2ray` failed to build, due to the missing linker flag.