### PR TITLE
fix: transpose (width, height) in python wrapper

### DIFF
--- a/wrappers/python/test.py
+++ b/wrappers/python/test.py
@@ -26,6 +26,23 @@ class Test(unittest.TestCase):
 		self.assertEqual(res.position.topLeft.x, 4)
 
 	@unittest.skipIf(not has_numpy, "need numpy for read/write tests")
+	def test_write_read_oned_cycle(self):
+		format = BF.CODE_128
+		text = "I have the best words."
+		height = 80
+		width = 400
+		img = zxing.write_barcode(format, text, width=width, height=height)
+		self.assertEqual(img.shape[0], height)
+		self.assertEqual(img.shape[1], width)
+
+		res = zxing.read_barcode(img)
+		self.assertTrue(res.valid)
+		self.assertEqual(res.format, format)
+		self.assertEqual(res.text, text)
+		self.assertEqual(res.orientation, 0)
+		self.assertEqual(res.position.topLeft.x, 61)
+
+	@unittest.skipIf(not has_numpy, "need numpy for read/write tests")
 	def test_failed_read(self):
 		import numpy as np
 		res = zxing.read_barcode(np.zeros((100, 100), np.uint8), formats = BF.EAN_8 | BF.AZTEC, binarizer = zxing.BoolCast)

--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -55,7 +55,7 @@ Image write_barcode(BarcodeFormat format, std::string text, int width, int heigh
 	auto writer = MultiFormatWriter(format).setMargin(margin).setEccLevel(eccLevel);
 	auto bitmap = writer.encode(TextUtfEncoding::FromUtf8(text), width, height);
 
-	auto result = Image({bitmap.width(), bitmap.height()});
+	auto result = Image({bitmap.height(), bitmap.width()});
 	auto r = result.mutable_unchecked<2>();
 	for (ssize_t y = 0; y < r.shape(0); y++)
 		for (ssize_t x = 0; x < r.shape(1); x++)


### PR DESCRIPTION
The dimensions for the output matrix in the python barcode writer were transposed, causing segfaults in non-square matrices.
This PR transposes the dimensions and adds a unit test to check output dimensions.