### PR TITLE
Fix compilation errors with -Werror=undef and add it to the flags.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,7 +25,7 @@ if (MSVC)
     )
 else()
     set (ZXING_CORE_LOCAL_DEFINES ${ZXING_CORE_LOCAL_DEFINES}
-        -Wall -Wextra -Wno-missing-braces)
+        -Wall -Wextra -Wno-missing-braces -Werror=undef)
 endif()
 
 

--- a/core/src/GenericLuminanceSource.cpp
+++ b/core/src/GenericLuminanceSource.cpp
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 
-#if (_MSC_VER >= 1915)
+#if defined(_MSC_VER) && (_MSC_VER >= 1915)
 #pragma warning(disable : 4996)
 #endif
 

--- a/core/src/datamatrix/DMSymbolInfo.cpp
+++ b/core/src/datamatrix/DMSymbolInfo.cpp
@@ -65,7 +65,7 @@ static const SymbolInfo PROD_SYMBOLS[] = {
 static const SymbolInfo* s_symbols = PROD_SYMBOLS;
 static ZXING_IF_NOT_TEST(const) size_t s_symbolCount = Size(PROD_SYMBOLS);
 
-#if ZXING_BUILD_FOR_TEST
+#ifdef ZXING_BUILD_FOR_TEST
 
 ZXING_EXPORT_TEST_ONLY
 void OverrideSymbolSet(const SymbolInfo* symbols, size_t count)


### PR DESCRIPTION
This allows to detect #if/#ifdef confusions.
I have it always on, which is how I stumbled upon this.