### PR TITLE
Fix Android compilation failure: no need for external threads lib

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -429,7 +429,9 @@ source_group (Sources\\textcodec FILES ${TEXT_CODEC_FILES})
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads REQUIRED)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+    find_package(Threads REQUIRED) # Not needed on Android, where pthread.h is part of the standard library.
+endif()
 
 add_library (ZXing
     ${COMMON_FILES}
@@ -465,7 +467,9 @@ endif()
 # the lib needs a c++-17 compiler but can be used with a c++-11 compiler (see examples)
 target_compile_features(ZXing PRIVATE cxx_std_17 INTERFACE cxx_std_11)
 
-target_link_libraries (ZXing PRIVATE Threads::Threads)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_link_libraries (ZXing PRIVATE Threads::Threads) # On Android, this is in the standard lib.
+endif()
 
 add_library(ZXing::ZXing ALIAS ZXing)
 # add the old alias as well, to keep old clients compiling


### PR DESCRIPTION
The line `find_package(Threads REQUIRED)` fails when cross-compiling for Android. In earlier versions where the Android build succeeded, this line had been `find_package(Threads)`, which only caused a non-fatal error.

Under Android, the libc standard library (called 'bionic') includes built-in support for pthreads ([see](https://stackoverflow.com/a/64432754)), so no external package has to be found and no threads library linked to when compiling for Android. So to solve the build issue, the PR excludes these actions when building for Android.

With the PR, builds under Android (requiring API level 16+ here) succeed again, and my application [foodrescue-app](https://github.com/fairdirect/foodrescue-app) that uses ZXing under Android works fine with the resulting library. (I did not try the official ZXing-C++ example applications under Android though, due to an unrelated build problem that is independent of the thread lib issue here and was present in earlier versions of ZXing.)

pthreads support is not complete in Android. But the pthreads functions that exist are POSIX compliant, and any function implemented in a non-POSIX-compliant way has a `_np` suffix in the name ([details](https://stackoverflow.com/a/58348085)). Since building ZXing succeeds, it means that all required pthreads functions are found in a POSIX-compliant implementation in the Android libc, and ZXing usage under Android is expected to be unaffected by the state of the pthreads implementation under Android.