### PR TITLE
fix/ Add C++17 build flag in CMakeList pybind

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
 project(ZXingPython)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # get pybind11
 include(FetchContent)
 #set(FETCHCONTENT_QUIET Off)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(ZXingPython)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # get pybind11
 include(FetchContent)
 #set(FETCHCONTENT_QUIET Off)
@@ -15,6 +12,10 @@ FetchContent_MakeAvailable (pybind11)
 # check if we are called from the top-level ZXing project
 get_directory_property(hasParent PARENT_DIRECTORY)
 if (NOT hasParent)
+    # Force to build by C++17. The zxing-cpp require C++17 to build
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
     option (BUILD_SHARED_LIBS "Link python module to shared lib" OFF)
     option (BUILD_WRITERS "Build with writer support (encoders)" ON)
     option (BUILD_READERS "Build with reader support (decoders)" ON)


### PR DESCRIPTION
Just add 2 flag of CMAKE  in CMakeLists.txt config to force the gcc build using C++17

set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED ON)

Otherwise  the command 'python setup.py install' will be failed on some machine. Because of requiring CPP > C++14 when building the binding lib