### PR TITLE
Fix build with GCC 11

### DIFF
--- a/core/src/Pattern.h
+++ b/core/src/Pattern.h
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <vector>
 


### PR DESCRIPTION
Starting with GCC 11, the  'limits' header is not included transitively anymore.