### PR TITLE
Fix incorrect class name, KRTextDecoder in KRTextEncoder.h

### DIFF
--- a/core/src/TextEncoder.cpp
+++ b/core/src/TextEncoder.cpp
@@ -256,7 +256,7 @@ TextEncoder::GetBytes(const std::wstring& str, CharacterSet charset, std::string
 	case CharacterSet::GB2312: GBTextEncoder::EncodeGB2312(str, bytes); break;
 	case CharacterSet::GB18030: GBTextEncoder::EncodeGB18030(str, bytes); break;
 	case CharacterSet::EUC_JP: JPTextEncoder::EncodeEUCJP(str, bytes); break;
-	case CharacterSet::EUC_KR: KRTextDecoder::EncodeEucKr(str, bytes); break;
+	case CharacterSet::EUC_KR: KRTextEncoder::EncodeEucKr(str, bytes); break;
 	case CharacterSet::UTF8: TextUtfEncoding::ToUtf8(str, bytes); break;
 	default: break;
 	}

--- a/core/src/textcodec/KRTextEncoder.cpp
+++ b/core/src/textcodec/KRTextEncoder.cpp
@@ -703,7 +703,7 @@ static uint16_t unicode2ksc(unsigned unicode)
 	return 0;
 }
 
-void KRTextDecoder::EncodeEucKr(const std::wstring& str, std::string& bytes)
+void KRTextEncoder::EncodeEucKr(const std::wstring& str, std::string& bytes)
 {
 	static const char replacement = '?';
 	//int invalid = 0;

--- a/core/src/textcodec/KRTextEncoder.h
+++ b/core/src/textcodec/KRTextEncoder.h
@@ -34,7 +34,7 @@
 
 #include <string>
 
-class KRTextDecoder
+class KRTextEncoder
 {
 public:
 	static void EncodeEucKr(const std::wstring& str, std::string& bytes);


### PR DESCRIPTION
`KRTextEncoder.h` has class `KRTextDecoder`. not **En**coder.

This will cause redeclaration error when include both `KRTextEncoder.h` and `KRTextDecoder.h`.