### PR TITLE
Add multi-file, one line option, non-graphical formatting to examples/ZXingReader

### DIFF
--- a/core/src/TextUtfEncoding.h
+++ b/core/src/TextUtfEncoding.h
@@ -23,6 +23,7 @@ namespace ZXing {
 namespace TextUtfEncoding {
 
 std::string ToUtf8(const std::wstring& str);
+std::string ToUtf8(const std::wstring& str, const bool angleEscape);
 std::wstring FromUtf8(const std::string& utf8);
 
 void ToUtf8(const std::wstring& str, std::string& utf8);

--- a/core/src/oned/ODMultiUPCEANReader.cpp
+++ b/core/src/oned/ODMultiUPCEANReader.cpp
@@ -359,7 +359,7 @@ Result MultiUPCEANReader::decodePattern(int rowNumber, const PatternView& row, s
 
 	auto ext = res.end;
 	PartialResult extRes;
-	if (_hints.requireEanAddOnSymbol() && ext.skipSymbol() && ext.skipSingle(static_cast<int>(begin.sum() * 3.5)) &&
+	if (ext.skipSymbol() && ext.skipSingle(static_cast<int>(begin.sum() * 3.5)) &&
 		(Extension(extRes, ext, 5) || Extension(extRes, ext, 2))) {
 
 		//TODO: extend position in include extension

--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -21,7 +21,9 @@
 #include <cctype>
 #include <chrono>
 #include <cstring>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -31,11 +33,12 @@ using namespace ZXing;
 
 static void PrintUsage(const char* exePath)
 {
-	std::cout << "Usage: " << exePath << " [-fast] [-norotate] [-format <FORMAT[,...]>] [-ispure] <png image path>\n"
+	std::cout << "Usage: " << exePath << " [-fast] [-norotate] [-format <FORMAT[,...]>] [-ispure] [-1] <png image path>...\n"
 			  << "    -fast      Skip some lines/pixels during detection (faster)\n"
 			  << "    -norotate  Don't try rotated image during detection (faster)\n"
 			  << "    -format    Only detect given format(s) (faster)\n"
 			  << "    -ispure    Assume the image contains only a 'pure'/perfect code (faster)\n"
+			  << "    -1         Print only file name, text and status on one line per file\n"
 			  << "\n"
 			  << "Supported formats are:\n";
 	for (auto f : BarcodeFormats::all()) {
@@ -44,7 +47,7 @@ static void PrintUsage(const char* exePath)
 	std::cout << "Formats can be lowercase, with or without '-', separated by ',' and/or '|'\n";
 }
 
-static bool ParseOptions(int argc, char* argv[], DecodeHints* hints, std::string* filePath)
+static bool ParseOptions(int argc, char* argv[], DecodeHints* hints, bool& oneLine, std::list<std::string>& filePaths)
 {
 	for (int i = 1; i < argc; ++i) {
 		if (strcmp(argv[i], "-fast") == 0) {
@@ -67,12 +70,51 @@ static bool ParseOptions(int argc, char* argv[], DecodeHints* hints, std::string
 				return false;
 			}
 		}
+		else if (strcmp(argv[i], "-1") == 0) {
+			oneLine = true;
+		}
 		else {
-			*filePath = argv[i];
+			filePaths.push_back(argv[i]);
 		}
 	}
 
-	return !filePath->empty();
+	return !filePaths.empty();
+}
+
+// Convert to UTF-8, placing non-graphical characters in angle brackets with text name
+static std::string FormatText(const std::wstring& text) {
+	static const char* const ascii_nongraphicals[33] = {
+		"NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
+		 "BS",  "HT",  "LF",  "VT",  "FF",  "CR",  "SO",  "SI",
+		"DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
+		"CAN",  "EM", "SUB", "ESC",  "FS",  "GS",  "RS",  "US",
+		"DEL",
+	};
+	std::wostringstream ws;
+
+	ws.fill(L'0');
+
+	for (wchar_t wc : text) {
+		if (wc < 128) { // ASCII
+			if (wc < 32 || wc == 127) { // Non-graphical ASCII, excluding space
+				ws << "<" << ascii_nongraphicals[wc == 127 ? 33 : wc] << ">";
+			}
+			else {
+				ws << wc;
+			}
+		}
+		else {
+			if ((wc >= 0xd800 && wc < 0xe000) || std::iswgraph(wc)) { // Include surrogates
+				ws << wc;
+			}
+			else { // Non-graphical Unicode
+				int width = wc < 256 ? 2 : 4;
+				ws << "<U+" << std::setw(width) << std::uppercase << std::hex << static_cast<unsigned int>(wc) << ">";
+			}
+		}
+	}
+
+	return TextUtfEncoding::ToUtf8(ws.str());
 }
 
 std::ostream& operator<<(std::ostream& os, const Position& points) {
@@ -84,39 +126,76 @@ std::ostream& operator<<(std::ostream& os, const Position& points) {
 int main(int argc, char* argv[])
 {
 	DecodeHints hints;
-	std::string filePath;
+	std::list<std::string> filePaths;
+	bool oneLine = false;
+	int fileCount = 0;
+	int ret = 0;
 
-	if (!ParseOptions(argc, argv, &hints, &filePath)) {
+	std::setlocale(LC_ALL, "en_US.UTF-8");
+
+	if (!ParseOptions(argc, argv, &hints, oneLine, filePaths)) {
 		PrintUsage(argv[0]);
 		return -1;
 	}
 
-	int width, height, channels;
-	std::unique_ptr<stbi_uc, void(*)(void*)> buffer(stbi_load(filePath.c_str(), &width, &height, &channels, 4), stbi_image_free);
-	if (buffer == nullptr) {
-		std::cerr << "Failed to read image: " << filePath << "\n";
-		return -1;
+	for (std::string filePath : filePaths) {
+		int width, height, channels;
+		std::unique_ptr<stbi_uc, void(*)(void*)> buffer(stbi_load(filePath.c_str(), &width, &height, &channels, 4), stbi_image_free);
+		if (buffer == nullptr) {
+			std::cerr << "Failed to read image: " << filePath << "\n";
+			return -1;
+		}
+		fileCount++;
+
+		const auto& result = ReadBarcode({buffer.get(), width, height, ImageFormat::RGBX}, hints);
+		const auto& meta = result.metadata();
+
+		ret |= static_cast<int>(result.status());
+
+		if (oneLine) {
+			if (!meta.getString(ResultMetadata::UPC_EAN_EXTENSION).empty()) {
+				std::cout << filePath << " \"" << FormatText(result.text())
+						  << "+" << FormatText(meta.getString(ResultMetadata::UPC_EAN_EXTENSION)) << "\" "
+						  << ToString(result.status()) << "\n";
+			}
+			else {
+				std::cout << filePath << " \"" << FormatText(result.text()) << "\" " << ToString(result.status()) << "\n";
+			}
+			continue;
+		}
+
+		if (filePaths.size() > 1) {
+			if (fileCount > 1) {
+				std::cout << "\n";
+			}
+			std::cout << "File:     " << filePath << "\n";
+		}
+		std::cout << "Text:     \"" << FormatText(result.text()) << "\"\n"
+				  << "Format:   " << ToString(result.format()) << "\n"
+				  << "Position: " << result.position() << "\n"
+				  << "Rotation: " << result.orientation() << " deg\n"
+				  << "Error:    " << ToString(result.status()) << "\n";
+
+		std::map<ResultMetadata::Key, const char*> keys = {{ResultMetadata::ERROR_CORRECTION_LEVEL, "EC Level: "},
+														   {ResultMetadata::POSSIBLE_COUNTRY, "Country:  "}};
+
+		for (auto key : keys) {
+			auto value = TextUtfEncoding::ToUtf8(meta.getString(key.first));
+			if (value.size())
+				std::cout << key.second << value << "\n";
+		}
+
+		if (!meta.getString(ResultMetadata::UPC_EAN_EXTENSION).empty()) {
+			std::cout << "Add-on:   \"" << FormatText(meta.getString(ResultMetadata::UPC_EAN_EXTENSION)) << "\"";
+			if (!meta.getString(ResultMetadata::ISSUE_NUMBER).empty()) {
+				std::cout << " (Issue #" << FormatText(meta.getString(ResultMetadata::ISSUE_NUMBER)) << ")";
+			}
+			else if (!meta.getString(ResultMetadata::SUGGESTED_PRICE).empty()) {
+				std::cout << " (Price " << FormatText(meta.getString(ResultMetadata::SUGGESTED_PRICE)) << ")";
+			}
+			std::cout << "\n";
+		}
 	}
 
-	auto result = ReadBarcode({buffer.get(), width, height, ImageFormat::RGBX}, hints);
-
-	std::cout << "Text:     \"" << TextUtfEncoding::ToUtf8(result.text()) << "\"\n"
-			  << "Format:   " << ToString(result.format()) << "\n"
-			  << "Position: " << result.position() << "\n"
-			  << "Rotation: " << result.orientation() << " deg\n"
-			  << "Error:    " << ToString(result.status()) << "\n";
-
-	std::map<ResultMetadata::Key, const char*> keys = {{ResultMetadata::ERROR_CORRECTION_LEVEL, "EC Level: "},
-													   {ResultMetadata::SUGGESTED_PRICE, "Price:    "},
-													   {ResultMetadata::ISSUE_NUMBER, "Issue #:  "},
-													   {ResultMetadata::POSSIBLE_COUNTRY, "Country:  "},
-													   {ResultMetadata::UPC_EAN_EXTENSION, "Extension:"}};
-
-	for (auto key : keys) {
-		auto value = TextUtfEncoding::ToUtf8(result.metadata().getString(key.first));
-		if (value.size())
-			std::cout << key.second << value << "\n";
-	}
-
-	return static_cast<int>(result.status());
+	return ret;
 }

--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
 	int fileCount = 0;
 	int ret = 0;
 
-	std::setlocale(LC_ALL, "en_US.UTF-8");
+	std::setlocale(LC_ALL, "en_US.UTF-8"); // Needed for `std::iswgraph()`
 
 	if (!ParseOptions(argc, argv, &hints, oneLine, filePaths)) {
 		PrintUsage(argv[0]);

--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -20,7 +20,9 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <clocale>
 #include <cstring>
+#include <cwctype>
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable (UnitTest
     PseudoRandom.h
     BitHacksTest.cpp
     ReedSolomonTest.cpp
+    TextUtfEncodingTest.cpp
     aztec/AZDetectorTest.cpp
     aztec/AZDecoderTest.cpp
     aztec/AZEncoderTest.cpp

--- a/test/unit/TextUtfEncodingTest.cpp
+++ b/test/unit/TextUtfEncodingTest.cpp
@@ -1,0 +1,52 @@
+/*
+* Copyright 2021 gitlost
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "TextUtfEncoding.h"
+
+#include "gtest/gtest.h"
+#include <clocale>
+#include <vector>
+
+TEST(ToUtf8AngleEscapeTest, TextUtfEncoding)
+{
+	using namespace ZXing::TextUtfEncoding;
+
+	bool angleEscape = true;
+
+	char* ctype_locale = std::setlocale(LC_CTYPE, NULL);
+	EXPECT_STREQ(ctype_locale, "C");
+
+	EXPECT_EQ(ToUtf8(std::wstring(L"¶Ж"), angleEscape), std::string("<U+B6><U+0416>"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"☂"), angleEscape), std::string("<U+2602>"));
+
+	std::setlocale(LC_CTYPE, "en_US.UTF-8");
+
+	EXPECT_EQ(ToUtf8(std::wstring(L"¶Ж"), angleEscape), std::string("¶Ж"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"☂"), angleEscape), std::string("☂"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\x01\x1F\x7F"), angleEscape), std::string("<SOH><US><DEL>"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\x80\x9F"), angleEscape), std::string("<U+80><U+9F>"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\xA0"), angleEscape), std::string("<U+A0>")); // NO-BREAK space (nbsp)
+	EXPECT_EQ(ToUtf8(std::wstring(L"\x2007"), angleEscape), std::string("<U+2007>")); // NO-BREAK space (numsp)
+	EXPECT_EQ(ToUtf8(std::wstring(L"\xFFEF"), angleEscape), std::string("<U+FFEF>")); // Was NO-BREAK space but now isn't (BOM)
+	EXPECT_EQ(ToUtf8(std::wstring(L"\u0100"), angleEscape), std::string("Ā"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\u1000"), angleEscape), std::string("က"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\u2000"), angleEscape), std::string("<U+2000>"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\uFFFD"), angleEscape), std::string("�"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\uFFFF"), angleEscape), std::string("<U+FFFF>"));
+	EXPECT_EQ(ToUtf8(std::wstring(L"\U00010000"), angleEscape), std::string("𐀀"));
+
+	std::setlocale(LC_CTYPE, ctype_locale);
+}

--- a/test/unit/TextUtfEncodingTest.cpp
+++ b/test/unit/TextUtfEncodingTest.cpp
@@ -72,4 +72,3 @@ TEST(TextUtfEncoding, ToUtf8AngleEscapeTest)
 
 	std::setlocale(LC_CTYPE, ctype_locale);
 }
-


### PR DESCRIPTION
Adds multi-file handling and `-1` one line option to `example/ZXingReader`, and formats any non-graphical characters in the text into angle brackets (e.g. a linefeed becomes `<LF>`).

Also renames `Extension` -> `Add-on` (the standard name) and puts the actual value in quotes, with the formatted value appended (as interpretation can vary).

Removes the `_hints.requireEanAddOnSymbol()` check from `ODMultiUPCEANReader` when setting UPC_EAN_EXTENSION metadata so that it gets set if present anyway. I notice the check was added [here](https://github.com/nu-book/zxing-cpp/commit/10854f5edd73d18774cb8cda6bede3094a886363#diff-030e736c55f5432ae3f6e18016e565fb51ecc2240fe1c0fcedaf0d51ff75d4baR340) but it doesn't appear to be necessary.


