### PR TITLE
Useful updates to cmake file

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -454,6 +454,7 @@ add_library(ZXing::ZXing ALIAS ZXing)
 add_library(ZXing::Core ALIAS ZXing)
 
 set_target_properties(ZXing PROPERTIES EXPORT_NAME ZXing)
+set_target_properties(ZXing PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if (PROJECT_VERSION)
     set_target_properties(ZXing PROPERTIES VERSION ${PROJECT_VERSION})
     set_target_properties(ZXing PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -468,3 +468,12 @@ install (
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     INCLUDES DESTINATION include
 )
+
+if(MSVC)
+    set_target_properties(ZXing PROPERTIES
+        COMPILE_PDB_NAME ZXing
+        COMPILE_PDB_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            CONFIGURATIONS Debug RelWithDebInfo)
+endif()


### PR DESCRIPTION
These are a couple of patches I have locally to improve the cmake file.
First installs the .pdb file allow with the libs on windows, for debug variants of the build.
Second enables position-independent-code compile option.