### PR TITLE
PDF417 Macro: fileId decode; segmentIndex 0 -> -1; Macro only symbol

### DIFF
--- a/core/src/pdf417/PDFDecodedBitStreamParser.cpp
+++ b/core/src/pdf417/PDFDecodedBitStreamParser.cpp
@@ -742,6 +742,8 @@ DecodedBitStreamParser::Decode(const std::vector<int>& codewords, int ecLevel)
 			status = DecodeStatus::FormatError;
 		}
 	}
+	if (resultString.empty() && resultMetadata->segmentIndex() == -1)
+		return DecodeStatus::FormatError;
 
 	if (StatusIsError(status))
 		return status;

--- a/core/src/pdf417/PDFDecodedBitStreamParser.cpp
+++ b/core/src/pdf417/PDFDecodedBitStreamParser.cpp
@@ -575,6 +575,9 @@ DecodeStatus DecodeMacroBlock(const std::vector<int>& codewords, int codeIndex, 
 	}
 	resultMetadata.setSegmentIndex(std::stoi(strBuf));
 
+	// Decoding the fileId codewords as 0-899 numbers, each 0-filled to width 3. This follows the spec
+	// (See ISO/IEC 15438:2015 Annex H.6) and preserves all info, but some generators (e.g. TEC-IT) write
+	// the fileId using text compaction, so in those cases the fileId will appear mangled.
 	std::ostringstream fileId;
 	fileId.fill('0');
 	for (int i = 0; codeIndex < codewords[0] && codewords[codeIndex] != MACRO_PDF417_TERMINATOR

--- a/core/src/pdf417/PDFDecoderResultExtra.h
+++ b/core/src/pdf417/PDFDecoderResultExtra.h
@@ -29,7 +29,7 @@ namespace Pdf417 {
 */
 class DecoderResultExtra : public CustomData
 {
-	int _segmentIndex = 0;
+	int _segmentIndex = -1;
 	std::string _fileId;
 	std::vector<int> _optionalData;
 	bool _lastSegment = false;
@@ -47,6 +47,7 @@ public:
 		return _segmentIndex;
 	}
 
+	// -1 if not set
 	void setSegmentIndex(int segmentIndex) {
 		_segmentIndex = segmentIndex;
 	}

--- a/core/src/pdf417/PDFReader.cpp
+++ b/core/src/pdf417/PDFReader.cpp
@@ -164,7 +164,7 @@ SymbolInfo ReadSymbolInfo(BitMatrixCursor<POINT> topCur, POINT rowSkip, int colW
 	SymbolInfo res = {width, height};
 	res.colWidth = colWidth;
 	int clusterMask = 0;
-	int rows0, rows1;
+	int rows0 = 0, rows1 = 0; // Suppress GNUC -Wmaybe-uninitialized
 
 	topCur.p += .5f * rowSkip;
 

--- a/test/blackbox/BlackboxTestRunner.cpp
+++ b/test/blackbox/BlackboxTestRunner.cpp
@@ -553,7 +553,9 @@ int runBlackBoxTests(const fs::path& testPathPrefix, const std::set<std::string>
 
 		runTests("pdf417-1", "PDF417", 15, {
 			{ 14, 14, 0   },
+			{  1,  1, 90  },
 			{ 14, 14, 180 },
+			{  1,  1, 270 },
 			{ 15, 0, pure },
 		});
 


### PR DESCRIPTION
Decodes the Macro PDF417 "fileId" codewords as 0-899 numbers, each 0-filled to width 3. Not doing any base 900 maths based on the example in ISO/IEC 15438:2015 Annex H.6, where (100, 200, 300) is transmitted as "100200300".

Sets the default of `segmentIndex` in PDFDecoderResultExtra to -1, and checks before setting `StructuredAppendInfo` (though check not really needed).

Allows a symbol to consist solely of a Macro (i.e. ~~removes check for `resultString` being empty~~ checks for non-existence on `resultString` empty check), as stated in Annex H.2 note.

Unit test additions. Also adds test entry that `pdf417-1/03-rot90.png` is readable when rotated 90 degrees.

Also suppresses a GNC maybe-uninitialized warning.