### PR TITLE
DMDecoder: add Structured Append handling

### DIFF
--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -33,9 +33,7 @@
 
 #include <algorithm>
 #include <array>
-#include <iomanip>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -146,12 +144,8 @@ static void ParseStructuredAppend(BitSource& bits, StructuredAppendInfo& sai)
 	int fileId2 = bits.readBits(8); // File identification 2
 
 	// There's no conversion method or meaning given to the 2 file id codewords in Section 5.6.3, apart from
-	// saying that each value should be 1-254. Choosing here to represent them as 2 0-filled 3 digit numbers
-	// (same as PDF417) as opposed to a base 254 representation (which TEC-IT uses a version of).
-	std::ostringstream fileId;
-	fileId.fill('0');
-	fileId << std::setw(3) << fileId1 << std::setw(3) << fileId2; // Allow 0 and 255
-	sai.id = fileId.str();
+	// saying that each value should be 1-254. Choosing here to represent them as base 256.
+	sai.id = std::to_string((fileId1 << 8) | fileId2);
 }
 
 /**

--- a/test/unit/datamatrix/DMDecodedBitStreamParserTest.cpp
+++ b/test/unit/datamatrix/DMDecodedBitStreamParserTest.cpp
@@ -99,3 +99,48 @@ TEST(DMDecodeTest, X12)
 	EXPECT_EQ(decode({238, 89, 233, 14, 192, 100, 207, 44, 31, 96, 82, 254, 70, 71, 129, 237}), L"ABC>ABC123>ABCDEF");
 //	EXPECT_EQ(decode({}), L"");
 }
+
+static StructuredAppendInfo info(ByteArray bytes)
+{
+	return DataMatrix::DecodedBitStreamParser::Decode(std::move(bytes), "").structuredAppend();
+}
+
+TEST(DMDecodeTest, StructuredAppend)
+{
+	// Null
+	EXPECT_EQ(info({50}).index, -1);
+	EXPECT_EQ(info({50}).count, -1);
+	EXPECT_TRUE(info({50}).id.empty());
+
+	// ISO/IEC 16022:2006 5.6.2 sequence indicator example
+	EXPECT_EQ(info({50, 233, 42, 1, 1}).index, 2); // 1-based position 3 == index 2
+	EXPECT_EQ(info({50, 233, 42, 1, 1}).count, 7);
+	EXPECT_EQ(info({50, 233, 42, 1, 1}).id, "001001");
+
+	// Sequence indicator
+	EXPECT_EQ(info({50, 233, 0, 1, 1}).index, 0);
+	EXPECT_EQ(info({50, 233, 0, 1, 1}).count, 0); // Count 17 set to 0
+
+	EXPECT_EQ(info({50, 233, 1, 1, 1}).index, 0);
+	EXPECT_EQ(info({50, 233, 1, 1, 1}).count, 16);
+
+	EXPECT_EQ(info({50, 233, 0x81, 1, 1}).index, 8);
+	EXPECT_EQ(info({50, 233, 0x81, 1, 1}).count, 16);
+
+	EXPECT_EQ(info({50, 233, 0xFF, 1, 1}).index, 15);
+	EXPECT_EQ(info({50, 233, 0xFF, 1, 1}).count, 0); // Count 2 <= index so set to 0
+
+	EXPECT_EQ(info({50, 233, 0xF1, 1, 1}).index, 15);
+	EXPECT_EQ(info({50, 233, 0xF1, 1, 1}).count, 16);
+
+	// File identification
+	EXPECT_EQ(info({50, 233, 42, 1, 12}).id, "001012");
+	EXPECT_EQ(info({50, 233, 42, 12, 34}).id, "012034");
+	EXPECT_EQ(info({50, 233, 42, 12, 123}).id, "012123");
+	EXPECT_EQ(info({50, 233, 42, 254, 254}).id, "254254");
+	// Values outside 1-254 allowed
+	EXPECT_EQ(info({50, 233, 42, 0, 0}).id, "000000");
+	EXPECT_EQ(info({50, 233, 42, 0, 255}).id, "000255");
+	EXPECT_EQ(info({50, 233, 42, 255, 0}).id, "255000");
+	EXPECT_EQ(info({50, 233, 42, 255, 255}).id, "255255");
+}

--- a/test/unit/datamatrix/DMDecodedBitStreamParserTest.cpp
+++ b/test/unit/datamatrix/DMDecodedBitStreamParserTest.cpp
@@ -115,7 +115,7 @@ TEST(DMDecodeTest, StructuredAppend)
 	// ISO/IEC 16022:2006 5.6.2 sequence indicator example
 	EXPECT_EQ(info({50, 233, 42, 1, 1}).index, 2); // 1-based position 3 == index 2
 	EXPECT_EQ(info({50, 233, 42, 1, 1}).count, 7);
-	EXPECT_EQ(info({50, 233, 42, 1, 1}).id, "001001");
+	EXPECT_EQ(info({50, 233, 42, 1, 1}).id, "257");
 
 	// Sequence indicator
 	EXPECT_EQ(info({50, 233, 0, 1, 1}).index, 0);
@@ -134,13 +134,13 @@ TEST(DMDecodeTest, StructuredAppend)
 	EXPECT_EQ(info({50, 233, 0xF1, 1, 1}).count, 16);
 
 	// File identification
-	EXPECT_EQ(info({50, 233, 42, 1, 12}).id, "001012");
-	EXPECT_EQ(info({50, 233, 42, 12, 34}).id, "012034");
-	EXPECT_EQ(info({50, 233, 42, 12, 123}).id, "012123");
-	EXPECT_EQ(info({50, 233, 42, 254, 254}).id, "254254");
-	// Values outside 1-254 allowed
-	EXPECT_EQ(info({50, 233, 42, 0, 0}).id, "000000");
-	EXPECT_EQ(info({50, 233, 42, 0, 255}).id, "000255");
-	EXPECT_EQ(info({50, 233, 42, 255, 0}).id, "255000");
-	EXPECT_EQ(info({50, 233, 42, 255, 255}).id, "255255");
+	EXPECT_EQ(info({50, 233, 42, 1, 12}).id, "268");
+	EXPECT_EQ(info({50, 233, 42, 12, 34}).id, "3106");
+	EXPECT_EQ(info({50, 233, 42, 12, 123}).id, "3195");
+	EXPECT_EQ(info({50, 233, 42, 254, 254}).id, "65278");
+	// Values outside 1-254 allowed (i.e. tolerated)
+	EXPECT_EQ(info({50, 233, 42, 0, 0}).id, "0");
+	EXPECT_EQ(info({50, 233, 42, 0, 255}).id, "255");
+	EXPECT_EQ(info({50, 233, 42, 255, 0}).id, "65280");
+	EXPECT_EQ(info({50, 233, 42, 255, 255}).id, "65535");
 }


### PR DESCRIPTION
Adds handling of Structured Append to Data Matrix.

The `fileId` is being saved as 2 0-filled 3-digit numbers, same as PDF417. Another choice would be to do a 254 base conversion to give a 0-64515 (or 1-64516) number instead.

Unit test.