### PR TITLE
cmake: add -Wshadow build flag and fix related shadowed variables

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,7 +25,7 @@ if (MSVC)
     )
 else()
     set (ZXING_CORE_LOCAL_DEFINES ${ZXING_CORE_LOCAL_DEFINES}
-        -Wall -Wextra -Wno-missing-braces -Werror=undef)
+        -Wall -Wextra -Wno-missing-braces -Werror=undef -Wshadow)
 endif()
 
 

--- a/core/src/BitMatrixCursor.h
+++ b/core/src/BitMatrixCursor.h
@@ -43,7 +43,7 @@ public:
 	POINT p; // current position
 	POINT d; // current direction
 
-	BitMatrixCursor(const BitMatrix& image, POINT p, POINT d) : img(&image), p(p) { setDirection(d); }
+	BitMatrixCursor(const BitMatrix& image, POINT _p, POINT _d) : img(&image), p(_p) { setDirection(_d); }
 
 	class Value
 	{
@@ -63,15 +63,15 @@ public:
 	};
 
 	template <typename T>
-	Value testAt(PointT<T> p) const
+	Value testAt(PointT<T> _p) const
 	{
-		return img->isIn(p) ? Value{img->get(p)} : Value{};
+		return img->isIn(_p) ? Value{img->get(_p)} : Value{};
 	}
 
 	bool blackAt(POINT pos) const noexcept { return testAt(pos).isBlack(); }
 	bool whiteAt(POINT pos) const noexcept { return testAt(pos).isWhite(); }
 
-	bool isIn(POINT p) const noexcept { return img->isIn(p); }
+	bool isIn(POINT _p) const noexcept { return img->isIn(_p); }
 	bool isIn() const noexcept { return isIn(p); }
 	bool isBlack() const noexcept { return blackAt(p); }
 	bool isWhite() const noexcept { return whiteAt(p); }
@@ -87,10 +87,10 @@ public:
 	void turnRight() noexcept { d = right(); }
 	void turn(Direction dir) noexcept { d = direction(dir); }
 
-	Value edgeAt(POINT d) const noexcept
+	Value edgeAt(POINT _d) const noexcept
 	{
 		Value v = testAt(p);
-		return testAt(p + d) != v ? v : Value();
+		return testAt(p + _d) != v ? v : Value();
 	}
 
 	Value edgeAtFront() const noexcept { return edgeAt(front()); }
@@ -108,10 +108,10 @@ public:
 		return isIn(p);
 	}
 
-	BitMatrixCursor<POINT> movedBy(POINT d) const
+	BitMatrixCursor<POINT> movedBy(POINT _d) const
 	{
 		auto res = *this;
-		res.p += d;
+		res.p += _d;
 		return res;
 	}
 

--- a/core/src/GenericGFPoly.cpp
+++ b/core/src/GenericGFPoly.cpp
@@ -37,7 +37,7 @@ GenericGFPoly::evaluateAt(int a) const
 
 	if (a == 1)
 		// Just the sum of the coefficients
-		return Reduce(_coefficients, 0, [](auto a, auto b) { return a ^ b; });
+		return Reduce(_coefficients, 0, [](auto i, auto j) { return i ^ j; });
 
 	int result = _coefficients[0];
 	for (size_t i = 1; i < _coefficients.size(); ++i)

--- a/core/src/PerspectiveTransform.h
+++ b/core/src/PerspectiveTransform.h
@@ -35,9 +35,10 @@ class PerspectiveTransform
 	value_t a11, a12, a13, a21, a22, a23, a31, a32, a33;
 	bool _isValid = false;
 
-	PerspectiveTransform(value_t a11, value_t a21, value_t a31, value_t a12, value_t a22, value_t a32, value_t a13,
-						 value_t a23, value_t a33)
-		: a11(a11), a12(a12), a13(a13), a21(a21), a22(a22), a23(a23), a31(a31), a32(a32), a33(a33), _isValid(true)
+	PerspectiveTransform(value_t _a11, value_t _a21, value_t _a31, value_t _a12, value_t _a22, value_t _a32,
+						 value_t _a13, value_t _a23, value_t _a33)
+		: a11(_a11), a12(_a12), a13(_a13), a21(_a21), a22(_a22), a23(_a23), a31(_a31), a32(_a32), a33(_a33),
+		_isValid(true)
 	{}
 
 	PerspectiveTransform inverse() const;

--- a/core/src/Point.h
+++ b/core/src/Point.h
@@ -28,7 +28,7 @@ struct PointT
 	T x = 0, y = 0;
 
 	constexpr PointT() = default;
-	constexpr PointT(T x, T y) : x(x), y(y) {}
+	constexpr PointT(T _x, T _y) : x(_x), y(_y) {}
 
 	template <typename U>
 	constexpr explicit PointT(const PointT<U>& p) : x(static_cast<T>(p.x)), y(static_cast<T>(p.y))

--- a/core/src/Scope.h
+++ b/core/src/Scope.h
@@ -28,7 +28,7 @@ class ScopeExit
 {
 	EF fn;
 public:
-	ScopeExit(EF&& fn) : fn(std::move(fn)) {}
+	ScopeExit(EF&& _fn) : fn(std::move(_fn)) {}
 	~ScopeExit() { fn(); }
 };
 

--- a/core/src/WhiteRectDetector.cpp
+++ b/core/src/WhiteRectDetector.cpp
@@ -267,29 +267,29 @@ bool DetectWhiteRect(const BitMatrix& image, int initSize, int x, int y, ResultP
 			return false;
 		}
 
-		ResultPoint x;
+		ResultPoint _x;
 		found = false;
 		//go down left
 		for (int i = 1; !found && i < maxSize; i++) {
-			found = GetBlackPointOnSegment(image, right, up + i, right - i, up, x);
+			found = GetBlackPointOnSegment(image, right, up + i, right - i, up, _x);
 		}
 
 		if (!found) {
 			return false;
 		}
 
-		ResultPoint y;
+		ResultPoint _y;
 		found = false;
 		//go up left
 		for (int i = 1; !found && i < maxSize; i++) {
-			found = GetBlackPointOnSegment(image, right, down - i, right - i, down, y);
+			found = GetBlackPointOnSegment(image, right, down - i, right - i, down, _y);
 		}
 
 		if (!found) {
 			return false;
 		}
 
-		CenterEdges(y, z, x, t, width, p0, p1, p2, p3);
+		CenterEdges(_y, z, _x, t, width, p0, p1, p2, p3);
 		return true;
 	}
 	else {

--- a/core/src/datamatrix/DMBitLayout.cpp
+++ b/core/src/datamatrix/DMBitLayout.cpp
@@ -54,23 +54,23 @@ BitMatrix VisitMatrix(int numRows, int numCols, VisitFunc visit)
 	int row = 4;
 	int col = 0;
 
-	auto corner = [&numRows, &numCols, logAccess](const BitPosArray& corner) {
+	auto corner = [&numRows, &numCols, logAccess](const BitPosArray& positions) {
 		auto clamp = [](int i, int max) { return i < 0 ? i + max : i; };
 		BitPosArray result;
 		for (size_t bit = 0; bit < 8; ++bit) {
-			result[bit] = {clamp(corner[bit].row, numRows), clamp(corner[bit].col, numCols)};
+			result[bit] = {clamp(positions[bit].row, numRows), clamp(positions[bit].col, numCols)};
 			logAccess(result[bit]);
 		}
 		return result;
 	};
 
-	auto utah = [&numRows, &numCols, logAccess](int row, int col) {
+	auto utah = [&numRows, &numCols, logAccess](int _row, int _col) {
 		const BitPosArray delta = {{{-2, -2}, {-2, -1}, {-1, -2}, {-1, -1}, {-1, 0}, {0, -2}, {0, -1}, {0, 0}}};
 
 		BitPosArray result;
 		for (size_t bit = 0; bit < 8; ++bit) {
-			int r = row + delta[bit].row;
-			int c = col + delta[bit].col;
+			int r = _row + delta[bit].row;
+			int c = _col + delta[bit].col;
 			if (r < 0) {
 				r += numRows;
 				c += 4 - ((numRows + 4) % 8);

--- a/core/src/oned/rss/ODRSSGenericAppIdDecoder.cpp
+++ b/core/src/oned/rss/ODRSSGenericAppIdDecoder.cpp
@@ -80,7 +80,7 @@ struct DecodedNumeric : public DecodedValue
 	int secondDigit = 0;
 
 	DecodedNumeric() = default;
-	DecodedNumeric(int newPosition, int first, int second) : DecodedValue(newPosition), firstDigit(first), secondDigit(second) {
+	DecodedNumeric(int position, int first, int second) : DecodedValue(position), firstDigit(first), secondDigit(second) {
 		if (firstDigit < 0 || firstDigit > 10 || secondDigit < 0 || secondDigit > 10) {
 			*this = DecodedNumeric();
 		}

--- a/core/src/pdf417/PDFDetector.cpp
+++ b/core/src/pdf417/PDFDetector.cpp
@@ -184,15 +184,15 @@ FindRowsWithPattern(const BitMatrix& matrix, int height, int width, int startRow
 		int previousRowStart = static_cast<int>(result[0].value().x());
 		int previousRowEnd = static_cast<int>(result[1].value().x());
 		for (; stopRow < height; stopRow++) {
-			int startPos, endPos;
-			found = FindGuardPattern(matrix, previousRowStart, stopRow, width, false, pattern, counters, startPos, endPos);
+			int start, end;
+			found = FindGuardPattern(matrix, previousRowStart, stopRow, width, false, pattern, counters, start, end);
 			// a found pattern is only considered to belong to the same barcode if the start and end positions
 			// don't differ too much. Pattern drift should be not bigger than two for consecutive rows. With
 			// a higher number of skipped rows drift could be larger. To keep it simple for now, we allow a slightly
 			// larger drift and don't check for skipped rows.
-			if (found && std::abs(previousRowStart - startPos) < MAX_PATTERN_DRIFT && std::abs(previousRowEnd - endPos) < MAX_PATTERN_DRIFT) {
-				previousRowStart = startPos;
-				previousRowEnd = endPos;
+			if (found && std::abs(previousRowStart - start) < MAX_PATTERN_DRIFT && std::abs(previousRowEnd - end) < MAX_PATTERN_DRIFT) {
+				previousRowStart = start;
+				previousRowEnd = end;
 				skippedRowCount = 0;
 			}
 			else if (skippedRowCount > SKIPPED_ROW_COUNT_MAX) {
@@ -316,7 +316,7 @@ static std::list<std::array<Nullable<ResultPoint>, 8>> DetectBarcode(const BitMa
 #ifdef ZX_FAST_BIT_STORAGE
 bool HasStartPattern(const BitMatrix& m)
 {
-	constexpr FixedPattern<8, 17> START_PATTERN = { 8, 1, 1, 1, 1, 1, 1, 3 };
+	constexpr FixedPattern<8, 17> FAST_START_PATTERN = { 8, 1, 1, 1, 1, 1, 1, 3 };
 	constexpr int minSymbolWidth = 3*8+1; // compact symbol
 
 	PatternRow row;
@@ -324,10 +324,10 @@ bool HasStartPattern(const BitMatrix& m)
 	for (int r = ROW_STEP; r < m.height(); r += ROW_STEP) {
 		m.getPatternRow(r, row);
 
-		if (FindLeftGuard(row, minSymbolWidth, START_PATTERN, 2).isValid())
+		if (FindLeftGuard(row, minSymbolWidth, FAST_START_PATTERN, 2).isValid())
 			return true;
 		std::reverse(row.begin(), row.end());
-		if (FindLeftGuard(row, minSymbolWidth, START_PATTERN, 2).isValid())
+		if (FindLeftGuard(row, minSymbolWidth, FAST_START_PATTERN, 2).isValid())
 			return true;
 	}
 

--- a/core/src/pdf417/PDFReader.cpp
+++ b/core/src/pdf417/PDFReader.cpp
@@ -126,8 +126,8 @@ struct SymbolInfo
 template<typename POINT>
 CodeWord ReadCodeWord(BitMatrixCursor<POINT>& cur, int expectedCluster = -1)
 {
-	auto readCodeWord = [expectedCluster](auto& cur) -> CodeWord {
-		auto np     = NormalizedPattern<8, 17>(cur.template readPattern<Pattern417>());
+	auto readCodeWord = [expectedCluster](auto& cursor) -> CodeWord {
+		auto np     = NormalizedPattern<8, 17>(cursor.template readPattern<Pattern417>());
 		int cluster = (np[0] - np[2] + np[4] - np[6] + 9) % 9;
 		int code = expectedCluster == -1 || cluster == expectedCluster ? CodewordDecoder::GetCodeword(ToInt(np)) : -1;
 
@@ -245,9 +245,9 @@ std::vector<int> ReadCodeWords(BitMatrixCursor<POINT> topCur, SymbolInfo info)
 		print(cw);
 
 		for (int col = 0; col < info.nCols && cur.isIn(); ++col) {
-			auto cw = ReadCodeWord(cur, cluster);
-			codeWords[row * info.nCols + col] = cw.code;
-			print(cw);
+			auto word = ReadCodeWord(cur, cluster);
+			codeWords[row * info.nCols + col] = word.code;
+			print(word);
 		}
 
 #ifdef PRINT_DEBUG

--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -237,8 +237,8 @@ static RegressionLine TraceLine(const BitMatrix& image, PointF p, PointF d, int 
 
 	line.evaluate(1.0, true);
 
-	for (auto p : line.points())
-		log(p, 2);
+	for (auto pt : line.points())
+		log(pt, 2);
 
 	return line;
 }


### PR DESCRIPTION
Suggestion to enable `-Wshadow` build flag, with fixes for the existing shadowed variables.

Builds fine, no warnings related to shadowing.
Unit tests pass.