### PR TITLE
Android: Using direct ByteBuffer to avoid memory allocation

### DIFF
--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
@@ -17,6 +17,7 @@
 package com.example.zxingcppdemo
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.*
@@ -24,6 +25,8 @@ import android.hardware.camera2.CaptureRequest
 import android.media.AudioManager
 import android.media.ToneGenerator
 import android.os.Bundle
+import android.util.Log
+import android.util.Size
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
@@ -34,7 +37,6 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.toPoint
-import androidx.core.graphics.toRectF
 import androidx.lifecycle.LifecycleOwner
 import com.example.zxingcpp.BarcodeReader
 import com.example.zxingcpp.BarcodeReader.Format
@@ -72,6 +74,7 @@ class MainActivity : AppCompatActivity() {
 		}
 	}
 
+	@SuppressLint("RestrictedApi")
 	private fun bindCameraUseCases() = view_finder.post {
 
 		val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
@@ -158,7 +161,7 @@ class MainActivity : AppCompatActivity() {
 					image.setCropRect(cropRect)
 
 					resultText = try {
-						val result = readerCpp.read(image)
+						val result = readerCpp.read2(image)
 						runtime2 += result?.time?.toInt() ?: 0
 						(result?.let { "${it.format}: ${it.text}" } ?: "")
 					} catch (e: Throwable) {
@@ -195,6 +198,11 @@ class MainActivity : AppCompatActivity() {
 			val camera = cameraProvider.bindToLifecycle(
 				this as LifecycleOwner, cameraSelector, preview, imageAnalysis
 			)
+
+			val selectedPreviewSize = preview.attachedSurfaceResolution ?: Size(0, 0)
+			val selectedImageAnalysisSize = imageAnalysis.attachedSurfaceResolution ?: Size(0, 0)
+			Log.i("MainActivity", "selectedPreviewSize: $selectedPreviewSize")
+			Log.i("MainActivity", "selectedImageAnalysisSize: $selectedImageAnalysisSize")
 
 			// Reduce exposure time to decrease effect of motion blur
 			val camera2 = Camera2CameraControl.from(camera.cameraControl)

--- a/wrappers/android/zxingcpp/src/main/cpp/BarcodeReader.cpp
+++ b/wrappers/android/zxingcpp/src/main/cpp/BarcodeReader.cpp
@@ -143,13 +143,14 @@ Java_com_example_zxingcpp_BarcodeReader_readYuvNative(JNIEnv *env, jobject thiz,
                                                       jobject y_byte_buffer, jint left, jint top,
                                                       jint width, jint height, jint rotation,
                                                       jstring formats, jboolean try_harder,
-                                                      jboolean try_rotate, jobject result) {
+                                                      jboolean try_rotate, jobject result,
+                                                      jint row_stride) {
 	using namespace ZXing;
 
 	try {
 		uint8_t* yBytes = static_cast<uint8_t *>(env->GetDirectBufferAddress(y_byte_buffer));
 
-		auto image = ImageView(yBytes, width, height, ImageFormat::Lum, width)
+		auto image = ImageView(yBytes, width, height, ImageFormat::Lum, row_stride)
 				.cropped(left, top, width, height)
 				.rotated(rotation);
 

--- a/wrappers/android/zxingcpp/src/main/java/com/example/zxingcpp/BarcodeReader.kt
+++ b/wrappers/android/zxingcpp/src/main/java/com/example/zxingcpp/BarcodeReader.kt
@@ -66,8 +66,11 @@ class BarcodeReader {
 
         return image.use {
             // This is a direct ByteBuffer which can let us access it from native directly without copying data
-            val yByteBuffer = it.planes[0].buffer
-            read(yByteBuffer = yByteBuffer, cropRect = it.cropRect, rotation = it.imageInfo.rotationDegrees)
+            val yPlane = it.planes[0]
+            read(yByteBuffer = yPlane.buffer,
+                rowStride = yPlane.rowStride,
+                cropRect = it.cropRect,
+                rotation = it.imageInfo.rotationDegrees)
         }
     }
 
@@ -90,6 +93,7 @@ class BarcodeReader {
 
     fun read(
         yByteBuffer: ByteBuffer,
+        rowStride: Int,
         options: Options = this.options,
         cropRect: Rect = Rect(),
         rotation: Int = 0,
@@ -97,7 +101,7 @@ class BarcodeReader {
         var result = Result()
         val status = with(options) {
             readYuvNative(yByteBuffer, cropRect.left, cropRect.top, cropRect.width(), cropRect.height(), rotation,
-                formats.joinToString(), tryHarder, tryRotate, result)
+                formats.joinToString(), tryHarder, tryRotate, result, rowStride)
         }
         return try {
             result.copy(format = Format.valueOf(status!!))
@@ -118,6 +122,7 @@ class BarcodeReader {
         yByteBuffer: ByteBuffer, left: Int, top: Int, width: Int, height: Int, rotation: Int,
         formats: String, tryHarder: Boolean, tryRotate: Boolean,
         result: Result,
+        rowStride: Int = width,
     ): String?
 
     init {


### PR DESCRIPTION
I make a little memory optimization when passing preview frame data from Kotlin to C++. Instead of creating an extra bitmap, we can use ByteBuffer from the ImageProxy. This ByteBuffer is guaranteed to be a direct ByteBuffer so we can get a pointer to it in native code.
 