### PR TITLE
DMDetector: fix one endless loop case with tryHarder config

### DIFF
--- a/core/src/datamatrix/DMDetector.cpp
+++ b/core/src/datamatrix/DMDetector.cpp
@@ -580,7 +580,7 @@ public:
 				// make sure we are making progress even when back-projecting:
 				// consider a 90deg corner, rotated 45deg. we step away perpendicular from the line and get
 				// back projected where we left off the line.
-				if (distance(np, line.project(line.points().back())) < 1)
+				while (distance(np, line.project(line.points().back())) < 1)
 					np = np + d;
 				p = centered(np);
 			}


### PR DESCRIPTION
When set `tryHarder` to `true`, I encountered an endless loop reading a DataMatrix code attached.
Endless loop found in traceGaps()
(105, 972) step
(106, 971) step
(107, 970) drift too much, project back to (104, 973) which doesn’t make any progress along line direction
and step back to (105, 972) fall in endless loop

A fix is to make sure when projecting back to traced line we are making progress in the line direction, the new position is not close to the old position.
[2021-08-24-09-05-32.png.zip](https://github.com/nu-book/zxing-cpp/files/7039156/2021-08-24-09-05-32.png.zip)
