### PR TITLE
PDF417: Fix "vector out of range" exception

### DIFF
--- a/core/src/pdf417/PDFBoundingBox.cpp
+++ b/core/src/pdf417/PDFBoundingBox.cpp
@@ -54,7 +54,7 @@ BoundingBox::calculateMinMaxValues()
 	}
 	else if (_topRight == nullptr) {
 		_topRight = ResultPoint(static_cast<float>(_imgWidth - 1), _topLeft.value().y());
-		_bottomRight = ResultPoint(static_cast<float>(_imgHeight - 1), _bottomLeft.value().y());
+		_bottomRight = ResultPoint(static_cast<float>(_imgWidth - 1), _bottomLeft.value().y());
 	}
 
 	_minX = static_cast<int>(std::min(_topLeft.value().x(), _bottomLeft.value().x()));


### PR DESCRIPTION
Fix bug with image height and width when creating a bounding box during pdf417 processing. This error occurred during processing an attached image with a barcode and led to a vector out of range exception (even in demo).
<img src="https://user-images.githubusercontent.com/48668507/130654000-03a912c4-9157-4877-a839-c60f33c4bc76.jpg" width="400" />
<img src="https://user-images.githubusercontent.com/48668507/130653976-fa965e58-156e-440d-9ef7-8412c8d3996c.png" width="500" />


