### PR TITLE
Fix #256, exception with checked iterator in VS debug build

### DIFF
--- a/core/src/oned/ODDataBarExpandedReader.cpp
+++ b/core/src/oned/ODDataBarExpandedReader.cpp
@@ -281,7 +281,8 @@ static bool FindValidSequence(const PairMap& all, ITER begin, ITER end, Pairs& s
 		constexpr int N = 2;
 		// TODO c++20 ranges::views::take()
 		auto& pairs = ppairs->second;
-		for (auto p = pairs.begin(), pend = std::min(pairs.end(), pairs.begin() + N); p != pend; ++p) {
+		int n = 0;
+		for (auto p = pairs.begin(), pend = pairs.end(); p != pend && n < N; ++p, ++n) {
 			// skip p if it is a half-pair but not the last one in the sequence
 			if (!p->right && std::next(begin) != end)
 				continue;


### PR DESCRIPTION
As mentioned by @stefankueng, this created by `pairs.begin() + N` which triggers exception in debug build with checked iterators since `pairs.begin() + N` even though it's only address and never be dereferenced