### PR TITLE
Enable -Werror=return-type and fix compilation

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,7 +25,7 @@ if (MSVC)
     )
 else()
     set (ZXING_CORE_LOCAL_DEFINES ${ZXING_CORE_LOCAL_DEFINES}
-        -Wall -Wextra -Wno-missing-braces -Werror=undef)
+        -Wall -Wextra -Wno-missing-braces -Werror=undef -Werror=return-type)
 endif()
 
 

--- a/core/src/ReadBarcode.cpp
+++ b/core/src/ReadBarcode.cpp
@@ -88,6 +88,7 @@ Result ReadBarcode(const ImageView& _iv, const DecodeHints& hints)
 	case Binarizer::GlobalHistogram: return MultiFormatReader(hints).read(GlobalHistogramBinarizer(iv));
 	case Binarizer::LocalAverage: return MultiFormatReader(hints).read(HybridBinarizer(iv));
 	}
+    return Result(DecodeStatus::FormatError);
 }
 
 Results ReadBarcodes(const ImageView& _iv, const DecodeHints& hints)
@@ -101,6 +102,7 @@ Results ReadBarcodes(const ImageView& _iv, const DecodeHints& hints)
 	case Binarizer::GlobalHistogram: return MultiFormatReader(hints).readMultiple(GlobalHistogramBinarizer(iv));
 	case Binarizer::LocalAverage: return MultiFormatReader(hints).readMultiple(HybridBinarizer(iv));
 	}
+    return {};
 }
 
 } // ZXing


### PR DESCRIPTION
The compiler doesn't know that the switch covers all cases
because technically any int can be stuffed into an enum value.

ReadBarcode.cpp:91:1: error: control reaches end of non-void function [-Werror=return-type]