### PR TITLE
+ install pdb only in shared build

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -469,9 +469,8 @@ if(MSVC)
     set_target_properties(ZXing PROPERTIES
         COMPILE_PDB_NAME ZXing
         COMPILE_PDB_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-    if(BUILD_SHARED_LIBS)
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                CONFIGURATIONS Debug RelWithDebInfo)
-    endif()
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            CONFIGURATIONS Debug RelWithDebInfo 
+            OPTIONAL)
 endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -469,7 +469,9 @@ if(MSVC)
     set_target_properties(ZXing PROPERTIES
         COMPILE_PDB_NAME ZXing
         COMPILE_PDB_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            CONFIGURATIONS Debug RelWithDebInfo)
+    if(BUILD_SHARED_LIBS)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                CONFIGURATIONS Debug RelWithDebInfo)
+    endif()
 endif()


### PR DESCRIPTION
... when packaging into vcpkg, it seems that for a static build there's no PDB generated, which caused an error

![image](https://user-images.githubusercontent.com/76251897/142604341-f6a1ecda-eef6-4f75-a791-9b6d23f4c80b.png)
