### PR TITLE
Fix python type hints on help(BarcodeFormat.__or__)

### DIFF
--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -113,6 +113,10 @@ Image write_barcode(BarcodeFormat format, std::string text, int width, int heigh
 PYBIND11_MODULE(zxingcpp, m)
 {
 	m.doc() = "python bindings for zxing-cpp";
+
+	// forward declaration of BarcodeFormats to fix BarcodeFormat function header typings
+	py::class_<BarcodeFormats> pyBarcodeFormats(m, "BarcodeFormats");
+
 	py::enum_<BarcodeFormat>(m, "BarcodeFormat", py::arithmetic{}, "Enumeration of zxing supported barcode formats")
 		.value("Aztec", BarcodeFormat::Aztec)
 		.value("Codabar", BarcodeFormat::Codabar)
@@ -137,7 +141,7 @@ PYBIND11_MODULE(zxingcpp, m)
 		.export_values()
 		// see https://github.com/pybind/pybind11/issues/2221
 		.def("__or__", [](BarcodeFormat f1, BarcodeFormat f2){ return f1 | f2; });
-	py::class_<BarcodeFormats>(m, "BarcodeFormats")
+	pyBarcodeFormats
 		.def("__repr__", py::overload_cast<BarcodeFormats>(&ToString))
 		.def("__str__", py::overload_cast<BarcodeFormats>(&ToString))
 		.def("__eq__", [](BarcodeFormats f1, BarcodeFormats f2){ return f1 == f2; })


### PR DESCRIPTION
This pull request fixes the types hints when one calls `help(BarcodeFormat.__or__)` on python
As the current code, when this is called, the interpreter shows the following output:

```
Help on instancemethod in module zxingcpp:

__or__(...)
    __or__(*args, **kwargs)
    Overloaded function.
    
    1. __or__(self: zxingcpp.BarcodeFormat, arg0: zxingcpp.BarcodeFormat) -> ZXing::Flags<ZXing::BarcodeFormat>
    
    2. __or__(self: ZXing::Flags<ZXing::BarcodeFormat>, arg0: zxingcpp.BarcodeFormat) -> ZXing::Flags<ZXing::BarcodeFormat>
```

which is unexpected, since the correct return type (and input on option 2.) on Python is `BarcodeFormats`.
This messes up with interpreters such as `pybind11-stubgen`, that tries to interpret this output to generate type hints for the module.

After this pull request, the output is as expected
```
Help on instancemethod in module zxingcpp:

__or__(...)
    __or__(*args, **kwargs)
    Overloaded function.
    
    1. __or__(self: zxingcpp.BarcodeFormat, arg0: zxingcpp.BarcodeFormat) -> zxingcpp.BarcodeFormats
    
    2. __or__(self: zxingcpp.BarcodeFormats, arg0: zxingcpp.BarcodeFormat) -> zxingcpp.BarcodeFormats
```