### PR TITLE
Fix for python OR operator between BarcodeFormat and BarcodeFormats

### DIFF
--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -136,12 +136,12 @@ PYBIND11_MODULE(zxingcpp, m)
 		.value("TwoDCodes", BarcodeFormat::TwoDCodes)
 		.export_values()
 		// see https://github.com/pybind/pybind11/issues/2221
-		.def("__or__", [](BarcodeFormat f1, BarcodeFormat f2){ return f1 | f2; })
-		.def("__or__", [](BarcodeFormats fs, BarcodeFormat f){ return fs | f; });
+		.def("__or__", [](BarcodeFormat f1, BarcodeFormat f2){ return f1 | f2; });
 	py::class_<BarcodeFormats>(m, "BarcodeFormats")
 		.def("__repr__", py::overload_cast<BarcodeFormats>(&ToString))
 		.def("__str__", py::overload_cast<BarcodeFormats>(&ToString))
 		.def("__eq__", [](BarcodeFormats f1, BarcodeFormats f2){ return f1 == f2; })
+		.def("__or__", [](BarcodeFormats fs, BarcodeFormat f){ return fs | f; })
 		.def(py::init<BarcodeFormat>());
 	py::implicitly_convertible<BarcodeFormat, BarcodeFormats>();
 	py::enum_<Binarizer>(m, "Binarizer", "Enumeration of binarizers used before decoding images")


### PR DESCRIPTION
This pull request addresses a problem when chaining multiple OR operators on BarcodeFormat.
As it is now, the following test yields an error:

```python
In [1]: import zxingcpp

In [2]: (zxingcpp.BarcodeFormat.NONE | zxingcpp.BarcodeFormat.Aztec) | zxingcpp.BarcodeFormat.Codabar
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-481ace235416> in <module>
----> 1 (zxingcpp.BarcodeFormat.NONE | zxingcpp.BarcodeFormat.Aztec) | zxingcpp.BarcodeFormat.Codabar

TypeError: unsupported operand type(s) for |: 'zxingcpp.BarcodeFormats' and 'zxingcpp.BarcodeFormat'
```

After this correction, it now works fine:
```python
In [1]: import zxingcpp

In [2]: (zxingcpp.BarcodeFormat.NONE | zxingcpp.BarcodeFormat.Aztec) | zxingcpp.BarcodeFormat.Codabar
Out[2]: Aztec|Codabar
```