### PR TITLE
Do not attempt to read barcodes from invalid images

### DIFF
--- a/example/ZXingQtReader.cpp
+++ b/example/ZXingQtReader.cpp
@@ -22,14 +22,26 @@ using namespace ZXingQt;
 
 int main(int argc, char* argv[])
 {
+	if (argc != 2) {
+		qDebug() << "Please supply exactly one image filename";
+		return 1;
+	}
+
 	QString filePath = argv[1];
+
+	QImage fileImage = QImage(filePath);
+
+	if (fileImage.isNull()) {
+		qDebug() << "Could not load the filename as an image:" << filePath;
+		return 1;
+	}
 
 	auto hints = DecodeHints()
 					 .setFormats(BarcodeFormat::QRCode)
 					 .setTryRotate(false)
 					 .setBinarizer(Binarizer::FixedThreshold);
 
-	auto result = ReadBarcode(QImage(filePath), hints);
+	auto result = ReadBarcode(fileImage, hints);
 
 	qDebug() << "Text:   " << result.text();
 	qDebug() << "Format: " << result.format();


### PR DESCRIPTION
Check that there is exactly one image filename and
check that the image contents were loaded correctly.

Fixes: SIGABRT