### PR TITLE
To get Windows build to work add depname arg to zxing_add_package

### DIFF
--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -1,5 +1,5 @@
 zxing_add_package_stb()
-zxing_add_package(fmt https://github.com/fmtlib/fmt.git 8.1.1)
+zxing_add_package(fmt fmtlib https://github.com/fmtlib/fmt.git 8.1.1)
 
 if (BUILD_READERS)
     add_executable (ReaderTest

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,8 +1,6 @@
-zxing_add_package(GTest https://github.com/google/googletest.git release-1.11.0)
+zxing_add_package(GTest googletest https://github.com/google/googletest.git release-1.11.0)
 
 if (GTest_POPULATED)
-    # Prevent overriding the parent project's compiler/linker settings on Windows
-    set (gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     # don't install gtest stuff on "make install"
     set (INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 endif()

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT hasParent)
         add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../core ZXing EXCLUDE_FROM_ALL)
 
         include(${CMAKE_CURRENT_SOURCE_DIR}/../../zxing.cmake)
-        zxing_add_package(pybind11 ${pybind11_git_repo} ${pybind11_git_rev})
+        zxing_add_package(pybind11 pybind11 ${pybind11_git_repo} ${pybind11_git_rev})
     else()
         # we don't have access to the top-level cmake helpers -> simply fetch it unconditional
         include(FetchContent)
@@ -55,7 +55,7 @@ if (NOT hasParent)
         endif()
     endif()
 else()
-    zxing_add_package(pybind11 ${pybind11_git_repo} ${pybind11_git_rev})
+    zxing_add_package(pybind11 pybind11 ${pybind11_git_repo} ${pybind11_git_rev})
 endif()
 
 # build the python module

--- a/zxing.cmake
+++ b/zxing.cmake
@@ -22,7 +22,7 @@ macro(zxing_add_package_stb)
     endif()
 endmacro()
 
-macro(zxing_add_package name git_repo git_rev)
+macro(zxing_add_package name depname git_repo git_rev)
     unset(${name}_FOUND CACHE) # see https://github.com/nu-book/zxing-cpp/commit/8db14eeead45e0f1961532f55061d5e4dd0f78be#commitcomment-66464026
 
     if (BUILD_DEPENDENCIES STREQUAL "AUTO")
@@ -33,10 +33,14 @@ macro(zxing_add_package name git_repo git_rev)
 
     if (NOT ${name}_FOUND)
         include(FetchContent)
-        FetchContent_Declare (${name}
+        FetchContent_Declare (${depname}
             GIT_REPOSITORY ${git_repo}
             GIT_TAG ${git_rev})
-        FetchContent_MakeAvailable (${name})
+        if (${depname} STREQUAL "googletest")
+            # Prevent overriding the parent project's compiler/linker settings on Windows
+            set (gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        endif()
+        FetchContent_MakeAvailable (${depname})
         set (${name}_POPULATED TRUE) # this is supposed to be done in MakeAvailable but it seems not to?!?
     endif()
 endmacro()


### PR DESCRIPTION
Seems need to use "googletest" as arg to `FetchContent_Declare()` and `FetchContent_MakeAvailable()` for Windows to build properly, so add a `depname` arg to `zxing_add_package()` (and update calling instances).

Also seems need to set `gtest_force_shared_crt` before calling `FetchContent_MakeAvailable()`, so add hacky test for this to `zxing_add_package()`.