### PR TITLE
ODCode128Reader: use FNC1 to determine if GS1, remove assumeGS1 (#265)

### DIFF
--- a/core/src/DecodeHints.h
+++ b/core/src/DecodeHints.h
@@ -74,6 +74,10 @@ public:
 	TYPE GETTER() const noexcept { return _##GETTER; } \
 	DecodeHints& SETTER(TYPE v) { return _##GETTER = std::move(v), *this; }
 
+#define ZX_PROPERTY_DEPRECATED(TYPE, GETTER, SETTER) \
+	[[deprecated]] TYPE GETTER() const noexcept { return _##GETTER; } \
+	[[deprecated]] DecodeHints& SETTER(TYPE v) { return _##GETTER = std::move(v), *this; }
+
 	/// Specify a set of BarcodeFormats that should be searched for, the default is all supported formats.
 	ZX_PROPERTY(BarcodeFormats, formats, setFormats)
 
@@ -103,9 +107,9 @@ public:
 
 	/**
 	* Assume the barcode is being processed as a GS1 barcode, and modify behavior as needed.
-	* For example this affects FNC1 handling for Code 128 (aka GS1-128).
+	* NOTE: used to affect FNC1 handling for Code 128 (aka GS1-128) but behavior now based on position of FNC1.
 	*/
-	ZX_PROPERTY(bool, assumeGS1, setAssumeGS1)
+	ZX_PROPERTY_DEPRECATED(bool, assumeGS1, setAssumeGS1)
 
 	/**
 	* If true, return the start and end digits in a Codabar barcode instead of stripping them. They
@@ -118,6 +122,7 @@ public:
 	ZX_PROPERTY(EanAddOnSymbol, eanAddOnSymbol, setEanAddOnSymbol)
 
 #undef ZX_PROPERTY
+#undef ZX_PROPERTY_DEPRECATED
 
 	bool hasFormat(BarcodeFormats f) const noexcept { return _formats.testFlags(f); }
 	bool hasNoFormat() const noexcept { return _formats.empty(); }

--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -45,6 +45,7 @@ class DecoderResult
 	std::wstring _ecLevel;
 	int _errorsCorrected = -1;
 	int _erasures = -1;
+	std::string _symbologyIdentifier;
 	StructuredAppendInfo _structuredAppend;
 	bool _readerInit = false;
 	std::shared_ptr<CustomData> _extra;
@@ -89,6 +90,7 @@ public:
 	ZX_PROPERTY(std::wstring, ecLevel, setEcLevel)
 	ZX_PROPERTY(int, errorsCorrected, setErrorsCorrected)
 	ZX_PROPERTY(int, erasures, setErasures)
+	ZX_PROPERTY(std::string, symbologyIdentifier, setSymbologyIdentifier)
 	ZX_PROPERTY(StructuredAppendInfo, structuredAppend, setStructuredAppend)
 	ZX_PROPERTY(bool, readerInit, setReaderInit)
 	ZX_PROPERTY(std::shared_ptr<CustomData>, extra, setExtra)

--- a/core/src/Result.cpp
+++ b/core/src/Result.cpp
@@ -26,23 +26,26 @@
 namespace ZXing {
 
 Result::Result(std::wstring&& text, Position&& position, BarcodeFormat format, ByteArray&& rawBytes,
-			   const bool readerInit)
+			   std::string symbologyIdentifier, StructuredAppendInfo sai, const bool readerInit)
 	: _format(format), _text(std::move(text)), _position(std::move(position)), _rawBytes(std::move(rawBytes)),
-	  _readerInit(readerInit)
+	  _symbologyIdentifier(symbologyIdentifier), _sai(sai), _readerInit(readerInit)
 {
 	_numBits = Size(_rawBytes) * 8;
 }
 
 Result::Result(const std::string& text, int y, int xStart, int xStop, BarcodeFormat format, ByteArray&& rawBytes,
-			   const bool readerInit)
-	: Result(TextDecoder::FromLatin1(text), Line(y, xStart, xStop), format, std::move(rawBytes), readerInit)
+			   std::string symbologyIdentifier, const bool readerInit)
+	: Result(TextDecoder::FromLatin1(text), Line(y, xStart, xStop), format, std::move(rawBytes), symbologyIdentifier,
+			 {}, readerInit)
 {}
 
 Result::Result(DecoderResult&& decodeResult, Position&& position, BarcodeFormat format)
 	: _status(decodeResult.errorCode()), _format(format), _text(std::move(decodeResult).text()),
 	  _position(std::move(position)), _rawBytes(std::move(decodeResult).rawBytes()), _numBits(decodeResult.numBits()),
-	  _ecLevel(decodeResult.ecLevel()), _sai(decodeResult.structuredAppend()), _readerInit(decodeResult.readerInit())
+	  _ecLevel(decodeResult.ecLevel()), _symbologyIdentifier(decodeResult.symbologyIdentifier()),
+	  _sai(decodeResult.structuredAppend()), _readerInit(decodeResult.readerInit())
 {
+
 	// TODO: add type opaque and code specific 'extra data'? (see DecoderResult::extra())
 }
 

--- a/core/src/Result.h
+++ b/core/src/Result.h
@@ -43,11 +43,11 @@ public:
 	explicit Result(DecodeStatus status) : _status(status) {}
 
 	Result(std::wstring&& text, Position&& position, BarcodeFormat format, ByteArray&& rawBytes = {},
-		   const bool readerInit = false);
+		   std::string symbologyIdentifier = "", StructuredAppendInfo sai = {}, const bool readerInit = false);
 
 	// 1D convenience constructor
 	Result(const std::string& text, int y, int xStart, int xStop, BarcodeFormat format, ByteArray&& rawBytes = {},
-		   const bool readerInit = false);
+		   std::string symbologyIdentifier = "", const bool readerInit = false);
 
 	Result(DecoderResult&& decodeResult, Position&& position, BarcodeFormat format);
 
@@ -79,13 +79,20 @@ public:
 	const ByteArray& rawBytes() const {
 		return _rawBytes;
 	}
-	
+
 	int numBits() const {
 		return _numBits;
 	}
 
 	const std::wstring& ecLevel() const {
 		return _ecLevel;
+	}
+
+	/**
+	 * @brief symbologyIdentifier Symbology identifier "]cm" where "c" is symbology code character, "m" the modifier.
+	 */
+	const std::string& symbologyIdentifier() const {
+		return _symbologyIdentifier;
 	}
 
 	/**
@@ -143,6 +150,7 @@ private:
 	ByteArray _rawBytes;
 	int _numBits = 0;
 	std::wstring _ecLevel;
+	std::string _symbologyIdentifier;
 	StructuredAppendInfo _sai;
 	bool _readerInit = false;
 	int _lineCount = 0;

--- a/core/src/oned/ODCode128Reader.cpp
+++ b/core/src/oned/ODCode128Reader.cpp
@@ -17,7 +17,6 @@
 
 #include "ODCode128Reader.h"
 
-#include "DecodeHints.h"
 #include "ODCode128Patterns.h"
 #include "Result.h"
 #include "ZXContainerAlgorithms.h"
@@ -53,7 +52,7 @@ static const int CODE_STOP = 106;
 class Raw2TxtDecoder
 {
 	int codeSet = 0;
-	bool _convertFNC1 = false;
+	std::string _symbologyIdentifier = "]C0"; // ISO/IEC 15417:2007 Annex C Table C.1
 	bool _readerInit = false;
 	std::string txt;
 	size_t lastTxtSize = 0;
@@ -62,23 +61,31 @@ class Raw2TxtDecoder
 	bool fnc4Next = false;
 	bool shift = false;
 
-	void fnc1()
+	void fnc1(const bool isCodeSetC)
 	{
-		if (_convertFNC1) {
-			if (txt.empty()) {
-				// GS1 specification 5.4.3.7. and 5.4.6.4. If the first char after the start code
-				// is FNC1 then this is GS1-128. We add the symbology identifier.
-				txt.append("]C1");
-			}
-			else {
-				// GS1 specification 5.4.7.5. Every subsequent FNC1 is returned as ASCII 29 (GS)
-				txt.push_back((char)29);
-			}
+		if (txt.empty()) {
+			// ISO/IEC 15417:2007 Annex B.1 and GS1 General Specifications 21.0.1 Section 5.4.3.7
+			// If the first char after the start code is FNC1 then this is GS1-128.
+			_symbologyIdentifier = "]C1";
+			// GS1 General Specifications Section 5.4.6.4
+			// "Transmitted data ... is prefixed by the symbology identifier ]C1, if used."
+			// Choosing not to use symbology identifier, i.e. to not prefix to data.
+		}
+		else if ((isCodeSetC && txt.size() == 2 && txt[0] >= '0' && txt[0] <= '9' && txt[1] >= '0' && txt[1] <= '9')
+				|| (!isCodeSetC && txt.size() == 1 && ((txt[0] >= 'A' && txt[0] <= 'Z')
+														|| (txt[0] >= 'a' && txt[0] <= 'z')))) {
+			// ISO/IEC 15417:2007 Annex B.2
+			// FNC1 in second position following Code Set C "00-99" or Code Set A/B "A-Za-z" - AIM
+			_symbologyIdentifier = "]C2";
+		}
+		else {
+			// ISO/IEC 15417:2007 Annex B.3. Otherwise FNC1 is returned as ASCII 29 (GS)
+			txt.push_back((char)29);
 		}
 	};
 
 public:
-	Raw2TxtDecoder(int startCode, bool convertFNC1) : codeSet(204 - startCode), _convertFNC1(convertFNC1)
+	Raw2TxtDecoder(int startCode) : codeSet(204 - startCode)
 	{
 		txt.reserve(20);
 	}
@@ -93,7 +100,7 @@ public:
 					txt.push_back('0');
 				txt.append(std::to_string(code));
 			} else if (code == CODE_FNC_1) {
-				fnc1();
+				fnc1(true /*isCodeSetC*/);
 			} else {
 				codeSet = code; // CODE_A / CODE_B
 			}
@@ -101,9 +108,9 @@ public:
 			bool unshift = shift;
 
 			switch (code) {
-			case CODE_FNC_1: fnc1(); break;
+			case CODE_FNC_1: fnc1(false /*isCodeSetC*/); break;
 			case CODE_FNC_2:
-				// do nothing?
+				// Message Append - do nothing?
 				break;
 			case CODE_FNC_3:
 				_readerInit = true; // Can occur anywhere in the symbol (ISO/IEC 15417:2007 4.3.4.2 (c))
@@ -157,6 +164,8 @@ public:
 		return txt.substr(0, lastTxtSize);
 	}
 
+	const std::string& symbologyIdentifier() const { return _symbologyIdentifier; }
+
 	bool readerInit() const { return _readerInit; }
 };
 
@@ -173,11 +182,6 @@ static int DetectStartCode(const C& c)
 		}
 	}
 	return bestVariance < MAX_AVG_VARIANCE ? bestCode : 0;
-}
-
-Code128Reader::Code128Reader(const DecodeHints& hints) :
-	_convertFNC1(hints.assumeGS1())
-{
 }
 
 // all 3 start patterns share the same 2-1-1 prefix
@@ -243,7 +247,7 @@ Result Code128Reader::decodePattern(int rowNumber, PatternView& next, std::uniqu
 	rawCodes.reserve(20);
 	rawCodes.push_back(static_cast<uint8_t>(startCode));
 
-	Raw2TxtDecoder raw2txt(startCode, _convertFNC1);
+	Raw2TxtDecoder raw2txt(startCode);
 
 	while (true) {
 		if (!next.skipSymbol())
@@ -281,7 +285,7 @@ Result Code128Reader::decodePattern(int rowNumber, PatternView& next, std::uniqu
 
 	int xStop = next.pixelsTillEnd();
 	return Result(raw2txt.text(), rowNumber, xStart, xStop, BarcodeFormat::Code128, std::move(rawCodes),
-				  raw2txt.readerInit());
+				  raw2txt.symbologyIdentifier(), raw2txt.readerInit());
 }
 
 } // namespace ZXing::OneD

--- a/core/src/oned/ODCode128Reader.h
+++ b/core/src/oned/ODCode128Reader.h
@@ -32,11 +32,7 @@ namespace OneD {
 class Code128Reader : public RowReader
 {
 public:
-	explicit Code128Reader(const DecodeHints& hints);
 	Result decodePattern(int rowNumber, PatternView& next, std::unique_ptr<DecodingState>&) const override;
-
-private:
-	bool _convertFNC1;
 };
 
 } // OneD

--- a/core/src/oned/ODReader.cpp
+++ b/core/src/oned/ODReader.cpp
@@ -52,7 +52,7 @@ Reader::Reader(const DecodeHints& hints) :
 	if (formats.testFlag(BarcodeFormat::Code93))
 		_readers.emplace_back(new Code93Reader());
 	if (formats.testFlag(BarcodeFormat::Code128))
-		_readers.emplace_back(new Code128Reader(hints));
+		_readers.emplace_back(new Code128Reader());
 	if (formats.testFlag(BarcodeFormat::ITF))
 		_readers.emplace_back(new ITFReader(hints));
 	if (formats.testFlag(BarcodeFormat::Codabar))

--- a/test/samples/code128-1/1.result.txt
+++ b/test/samples/code128-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C1

--- a/test/samples/code128-1/2.result.txt
+++ b/test/samples/code128-1/2.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C0

--- a/test/samples/code128-1/3.result.txt
+++ b/test/samples/code128-1/3.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C0

--- a/test/samples/code128-1/4.result.txt
+++ b/test/samples/code128-1/4.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C1

--- a/test/samples/code128-1/5.result.txt
+++ b/test/samples/code128-1/5.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C1

--- a/test/samples/code128-1/6.result.txt
+++ b/test/samples/code128-1/6.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]C0

--- a/test/unit/oned/ODCode128ReaderTest.cpp
+++ b/test/unit/oned/ODCode128ReaderTest.cpp
@@ -16,7 +16,6 @@
 
 #include "oned/ODCode128Reader.h"
 
-#include "DecodeHints.h"
 #include "Result.h"
 
 #include "gtest/gtest.h"
@@ -37,10 +36,60 @@ static Result parse(const int startPattern, PatternRow row)
 	row.insert(row.end(), { 2, 3, 3, 1, 1, 1, 2, 0 }); // Stop pattern
 
 	std::unique_ptr<Code128Reader::DecodingState> state;
-	DecodeHints hints;
-	Code128Reader reader(hints);
+	Code128Reader reader;
 	PatternView next(row);
 	return reader.decodePattern(0, next, state);
+}
+
+TEST(ODCode128ReaderTest, SymbologyIdentifier)
+{
+	{
+		// Plain "2001"
+		PatternRow row({ 2, 2, 1, 2, 3, 1, 2, 2, 2, 1, 2, 2, 3, 1, 1, 2, 2, 2 });
+		auto result = parse('C', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C0");
+		EXPECT_EQ(result.text(), L"2001");
+	}
+
+	{
+		// GS1 "(20)01"
+		PatternRow row({ 4, 1, 1, 1, 3, 1, 2, 2, 1, 2, 3, 1, 2, 2, 2, 1, 2, 2, 1, 3, 2, 1, 3, 1 });
+		auto result = parse('C', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C1");
+		EXPECT_EQ(result.text(), L"2001");
+	}
+
+	{
+		// AIM "A FNC1 B"
+		PatternRow row({ 1, 1, 1, 3, 2, 3, 4, 1, 1, 1, 3, 1, 1, 3, 1, 1, 2, 3, 2, 1, 2, 3, 2, 1 });
+		auto result = parse('B', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C2");
+		EXPECT_EQ(result.text(), L"AB");
+	}
+
+	{
+		// AIM "z FNC1 B"
+		PatternRow row({ 2, 1, 4, 1, 2, 1, 4, 1, 1, 1, 3, 1, 1, 3, 1, 1, 2, 3, 4, 2, 1, 2, 1, 1 });
+		auto result = parse('B', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C2");
+		EXPECT_EQ(result.text(), L"zB");
+	}
+
+	{
+		// AIM "99 FNC1 A"
+		PatternRow row({ 1, 1, 3, 1, 4, 1, 4, 1, 1, 1, 3, 1, 1, 1, 4, 1, 3, 1, 1, 1, 1, 3, 2, 3, 1, 2, 3, 1, 2, 2 });
+		auto result = parse('C', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C2");
+		EXPECT_EQ(result.text(), L"99A");
+	}
+
+	{
+		// Bad AIM Application Indicator "? FNC1 B"
+		PatternRow row({ 2, 1, 2, 3, 2, 1, 4, 1, 1, 1, 3, 1, 1, 3, 1, 1, 2, 3, 3, 2, 2, 2, 1, 1 });
+		auto result = parse('B', row);
+		EXPECT_EQ(result.symbologyIdentifier(), "]C0"); // Just ignoring, not giving FormatError
+		EXPECT_EQ(result.text(), L"?\u001DB");
+	}
 }
 
 TEST(ODCode128ReaderTest, ReaderInit)
@@ -48,21 +97,24 @@ TEST(ODCode128ReaderTest, ReaderInit)
 	{
 		// Null
 		PatternRow row({ 1, 1, 1, 1, 4, 3, 1, 3, 1, 1, 4, 1 });
-		EXPECT_FALSE(parse('C', row).readerInit());
-		EXPECT_EQ(parse('C', row).text(), L"92");
+		auto result = parse('C', row);
+		EXPECT_FALSE(result.readerInit());
+		EXPECT_EQ(result.text(), L"92");
 	}
 
 	{
 		// Set (FNC3 first)
 		PatternRow row({ 1, 1, 4, 3, 1, 1, 1, 1, 3, 1, 4, 1, 1, 1, 1, 1, 4, 3, 3, 3, 1, 1, 2, 1 });
-		EXPECT_TRUE(parse('B', row).readerInit());
-		EXPECT_EQ(parse('B', row).text(), L"92");
+		auto result = parse('B', row);
+		EXPECT_TRUE(result.readerInit());
+		EXPECT_EQ(result.text(), L"92");
 	}
 
 	{
 		// Set (FNC3 between "9" and "2" )
 		PatternRow row({ 3, 2, 1, 1, 2, 2, 1, 1, 4, 3, 1, 1, 2, 2, 3, 2, 1, 1, 1, 2, 1, 4, 2, 1 });
-		EXPECT_TRUE(parse('B', row).readerInit());
-		EXPECT_EQ(parse('B', row).text(), L"92");
+		auto result = parse('B', row);
+		EXPECT_TRUE(result.readerInit());
+		EXPECT_EQ(result.text(), L"92");
 	}
 }


### PR DESCRIPTION
Closes #265
Part-implements #214

For Code128, uses position of FNC1 to determine if GS1 (or AIM) barcode rather than `assumeGS1` hint which is no longer used and is marked as deprecated in `DecodeHints`.

Also sets new `symbologyIdentifier` attribute added to "Result.h" (implemented for Code128 only for now).

Adds processing of optional  ".result.txt" files in "test/samples" that contain keyed Result attributes and values for additional validation.

Implementation of further symbology identifiers will follow in subsequent PRs (also checking of other Result attributes in ".result.txt" files).