### PR TITLE
Implements symbologyIdentifier for Codabar, Code 93, DataBar, UPC/EAN (#214)

### DIFF
--- a/core/src/oned/ODCodabarReader.cpp
+++ b/core/src/oned/ODCodabarReader.cpp
@@ -103,8 +103,12 @@ CodabarReader::decodePattern(int rowNumber, PatternView& next, std::unique_ptr<D
 	if (!_returnStartEnd)
 		txt = txt.substr(1, txt.size() - 2);
 
+	// symbology identifier ISO/IEC 15424:2008 4.4.9
+	// if checksum processing were implemented and checksum present and stripped then modifier would be 4
+	std::string symbologyIdentifier("]F0");
+
 	int xStop = next.pixelsTillEnd();
-	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::Codabar);
+	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::Codabar, {}, std::move(symbologyIdentifier));
 }
 
 } // namespace ZXing::OneD

--- a/core/src/oned/ODCode93Reader.cpp
+++ b/core/src/oned/ODCode93Reader.cpp
@@ -134,8 +134,11 @@ Result Code93Reader::decodePattern(int rowNumber, PatternView& next, std::unique
 	if (!DecodeExtendedCode39AndCode93(txt, "abcd"))
 		return Result(DecodeStatus::FormatError);
 
+	// Symbology identifier ISO/IEC 15424:2008 4.4.10 no modifiers
+	std::string symbologyIdentifier("]G0");
+
 	int xStop = next.pixelsTillEnd();
-	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::Code93);
+	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::Code93, {}, std::move(symbologyIdentifier));
 }
 
 } // namespace ZXing::OneD

--- a/core/src/oned/ODDataBarExpandedReader.cpp
+++ b/core/src/oned/ODDataBarExpandedReader.cpp
@@ -370,11 +370,14 @@ Result DataBarExpandedReader::decodePattern(int rowNumber, PatternView& view,
 #endif
 
 	auto txt = DecodeExpandedBits(BuildBitArray(pairs));
-	if(txt.empty())
+	if (txt.empty())
 		return Result(DecodeStatus::NotFound);
 
+	// Symbology identifier ISO/IEC 24724:2011 Section 9 and GS1 General Specifications 5.1.3 Figure 5.1.3-2
+	std::string symbologyIdentifier("]e0");
+
 	return {TextDecoder::FromLatin1(txt), EstimatePosition(pairs.front(), pairs.back()),
-			BarcodeFormat::DataBarExpanded};
+			BarcodeFormat::DataBarExpanded, {}, symbologyIdentifier};
 }
 
 } // namespace ZXing::OneD

--- a/core/src/oned/ODDataBarReader.cpp
+++ b/core/src/oned/ODDataBarReader.cpp
@@ -203,11 +203,15 @@ Result DataBarReader::decodePattern(int rowNumber, PatternView& next,
 		}
 	}
 
+	// Symbology identifier ISO/IEC 24724:2011 Section 9 and GS1 General Specifications 5.1.3 Figure 5.1.3-2
+	std::string symbologyIdentifier("]e0");
+
 	for (const auto& leftPair : prevState->leftPairs)
 		for (const auto& rightPair : prevState->rightPairs)
 			if (ChecksumIsValid(leftPair, rightPair))
 				return {TextDecoder::FromLatin1(ConstructText(leftPair, rightPair)),
-						EstimatePosition(leftPair, rightPair), BarcodeFormat::DataBar};
+						EstimatePosition(leftPair, rightPair), BarcodeFormat::DataBar,
+						{}, std::move(symbologyIdentifier)};
 #endif
 
 	// guaratee progress (see loop in ODReader.cpp)

--- a/test/samples/codabar-1/01.result.txt
+++ b/test/samples/codabar-1/01.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]F0

--- a/test/samples/code93-1/1.result.txt
+++ b/test/samples/code93-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]G0

--- a/test/samples/ean13-1/1.result.txt
+++ b/test/samples/ean13-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E0

--- a/test/samples/ean13-extension-1/1.result.txt
+++ b/test/samples/ean13-extension-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E3

--- a/test/samples/ean8-1/1.result.txt
+++ b/test/samples/ean8-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E4

--- a/test/samples/rss14-1/1.result.txt
+++ b/test/samples/rss14-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]e0

--- a/test/samples/rssexpanded-1/1.result.txt
+++ b/test/samples/rssexpanded-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]e0

--- a/test/samples/rssexpandedstacked-1/1.result.txt
+++ b/test/samples/rssexpandedstacked-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]e0

--- a/test/samples/upca-1/2.result.txt
+++ b/test/samples/upca-1/2.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E0

--- a/test/samples/upca-extension-1/8.result.txt
+++ b/test/samples/upca-extension-1/8.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E3

--- a/test/samples/upce-1/1.result.txt
+++ b/test/samples/upce-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]E0


### PR DESCRIPTION
Part-implements #214

Implements symbologyIdentifier for Codabar, Code 93, DataBar Limited/Expanded (Stacked), UPC/E, UPC/A, EAN-13, EAN-8.

Adds sample "*.result.txt" files.

(Only ITF remains to be done, plus updating "ZXingReader.cpp" example to report "Identifier:" - PR will follow shortly).