### PR TITLE
Implements symbologyIdentifier for ITF (#214)

### DIFF
--- a/core/src/DecodeHints.h
+++ b/core/src/DecodeHints.h
@@ -57,6 +57,7 @@ class DecodeHints
 	bool _returnCodabarStartEnd : 1;
 	Binarizer _binarizer : 2;
 	EanAddOnSymbol _eanAddOnSymbol : 2;
+    bool _assumeITFCheckDigit : 1;
 
 	BarcodeFormats _formats = BarcodeFormat::None;
 	std::string _characterSet;
@@ -67,7 +68,7 @@ public:
 	DecodeHints()
 		: _tryHarder(1), _tryRotate(1), _isPure(0), _tryCode39ExtendedMode(0), _assumeCode39CheckDigit(0),
 		  _assumeGS1(0), _returnCodabarStartEnd(0), _binarizer(Binarizer::LocalAverage),
-		  _eanAddOnSymbol(EanAddOnSymbol::Ignore)
+		  _eanAddOnSymbol(EanAddOnSymbol::Ignore), _assumeITFCheckDigit(0)
 	{}
 
 #define ZX_PROPERTY(TYPE, GETTER, SETTER) \
@@ -120,6 +121,9 @@ public:
 
 	/// Specify whether to ignore, read or require EAN-2/5 add-on symbols while scanning EAN/UPC codes
 	ZX_PROPERTY(EanAddOnSymbol, eanAddOnSymbol, setEanAddOnSymbol)
+
+	/// Assume ITF codes employ a GS1 check digit.
+	ZX_PROPERTY(bool, assumeITFCheckDigit, setAssumeITFCheckDigit)
 
 #undef ZX_PROPERTY
 #undef ZX_PROPERTY_DEPRECATED

--- a/core/src/DecodeHints.h
+++ b/core/src/DecodeHints.h
@@ -53,11 +53,11 @@ class DecodeHints
 	bool _isPure : 1;
 	bool _tryCode39ExtendedMode : 1;
 	bool _assumeCode39CheckDigit : 1;
+	bool _assumeITFCheckDigit : 1;
 	bool _assumeGS1 : 1;
 	bool _returnCodabarStartEnd : 1;
 	Binarizer _binarizer : 2;
 	EanAddOnSymbol _eanAddOnSymbol : 2;
-    bool _assumeITFCheckDigit : 1;
 
 	BarcodeFormats _formats = BarcodeFormat::None;
 	std::string _characterSet;
@@ -67,8 +67,8 @@ public:
 	// bitfields don't get default initialized to 0.
 	DecodeHints()
 		: _tryHarder(1), _tryRotate(1), _isPure(0), _tryCode39ExtendedMode(0), _assumeCode39CheckDigit(0),
-		  _assumeGS1(0), _returnCodabarStartEnd(0), _binarizer(Binarizer::LocalAverage),
-		  _eanAddOnSymbol(EanAddOnSymbol::Ignore), _assumeITFCheckDigit(0)
+		  _assumeITFCheckDigit(0), _assumeGS1(0), _returnCodabarStartEnd(0), _binarizer(Binarizer::LocalAverage),
+		  _eanAddOnSymbol(EanAddOnSymbol::Ignore)
 	{}
 
 #define ZX_PROPERTY(TYPE, GETTER, SETTER) \
@@ -106,6 +106,9 @@ public:
 	/// Assume Code-39 codes employ a check digit.
 	ZX_PROPERTY(bool, assumeCode39CheckDigit, setAssumeCode39CheckDigit)
 
+	/// Assume ITF codes employ a GS1 check digit.
+	ZX_PROPERTY(bool, assumeITFCheckDigit, setAssumeITFCheckDigit)
+
 	/**
 	* Assume the barcode is being processed as a GS1 barcode, and modify behavior as needed.
 	* NOTE: used to affect FNC1 handling for Code 128 (aka GS1-128) but behavior now based on position of FNC1.
@@ -121,9 +124,6 @@ public:
 
 	/// Specify whether to ignore, read or require EAN-2/5 add-on symbols while scanning EAN/UPC codes
 	ZX_PROPERTY(EanAddOnSymbol, eanAddOnSymbol, setEanAddOnSymbol)
-
-	/// Assume ITF codes employ a GS1 check digit.
-	ZX_PROPERTY(bool, assumeITFCheckDigit, setAssumeITFCheckDigit)
 
 #undef ZX_PROPERTY
 #undef ZX_PROPERTY_DEPRECATED

--- a/core/src/oned/ODITFReader.cpp
+++ b/core/src/oned/ODITFReader.cpp
@@ -18,6 +18,7 @@
 #include "ODITFReader.h"
 
 #include "DecodeHints.h"
+#include "GTIN.h"
 #include "Result.h"
 #include "ZXContainerAlgorithms.h"
 
@@ -29,7 +30,8 @@ namespace ZXing::OneD {
 static const std::array<int, 5> DEFAULT_ALLOWED_LENGTHS = { 6, 8, 10, 12, 14 };
 
 ITFReader::ITFReader(const DecodeHints& hints) :
-	_allowedLengths(hints.allowedLengths())
+	_allowedLengths(hints.allowedLengths()),
+	_usingCheckDigit(hints.assumeITFCheckDigit())
 {
 	if (_allowedLengths.empty()) {
 		_allowedLengths.assign(DEFAULT_ALLOWED_LENGTHS.begin(), DEFAULT_ALLOWED_LENGTHS.end());
@@ -86,8 +88,18 @@ Result ITFReader::decodePattern(int rowNumber, PatternView& next, std::unique_pt
 	if (!IsRightGuard(next, STOP_PATTERN_1, minQuietZone) && !IsRightGuard(next, STOP_PATTERN_2, minQuietZone))
 		return Result(DecodeStatus::NotFound);
 
+	// Symbology identifier ISO/IEC 16390:2007 Annex C Table C.1
+	// See also GS1 General Specifications 5.1.3 Figure 5.1.3-2
+	std::string symbologyIdentifier("]I0"); // No check character validation
+
+	if (_usingCheckDigit && !GTIN::IsCheckDigitValid(txt))
+		return Result(DecodeStatus::ChecksumError);
+
+	if (_usingCheckDigit || (txt.size() == 14 && GTIN::IsCheckDigitValid(txt))) // If no hint test if valid ITF-14
+		symbologyIdentifier = "]I1"; // Modulo 10 symbol check character validated and transmitted
+
 	int xStop = next.pixelsTillEnd();
-	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::ITF);
+	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::ITF, {}, std::move(symbologyIdentifier));
 }
 
 } // namespace ZXing::OneD

--- a/core/src/oned/ODITFReader.h
+++ b/core/src/oned/ODITFReader.h
@@ -34,8 +34,7 @@ namespace OneD {
 * lengths are scanned, especially shorter ones, to avoid false positives. This in turn is due to a lack of
 * required checksum function.</p>
 *
-* <p>The checksum is optional and is not applied by this Reader. The consumer of the decoded
-* value will have to apply a checksum if required.</p>
+* <p>The checksum is optional and is only applied by this Reader if the assumeITFCheckDigit hint is given.</p>
 *
 * <p><a href="http://en.wikipedia.org/wiki/Interleaved_2_of_5">http://en.wikipedia.org/wiki/Interleaved_2_of_5</a>
 * is a great reference for Interleaved 2 of 5 information.</p>
@@ -50,6 +49,7 @@ public:
 
 private:
 	std::vector<int> _allowedLengths;
+	bool _usingCheckDigit;
 };
 
 } // OneD

--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -171,33 +171,34 @@ int main(int argc, char* argv[])
 				if (!firstFile)
 					std::cout << "\n";
 				if (filePaths.size() > 1)
-					std::cout << "File:     " << filePath << "\n";
+					std::cout << "File:       " << filePath << "\n";
 				firstFile = false;
 			}
-			std::cout << "Text:     \"" << ToUtf8(result.text(), angleEscape) << "\"\n"
-					  << "Format:   " << ToString(result.format()) << "\n"
-					  << "Position: " << result.position() << "\n"
-					  << "Rotation: " << result.orientation() << " deg\n"
-					  << "Error:    " << ToString(result.status()) << "\n";
+			std::cout << "Text:       \"" << ToUtf8(result.text(), angleEscape) << "\"\n"
+					  << "Format:     " << ToString(result.format()) << "\n"
+					  << "Identifier: " << result.symbologyIdentifier() << "\n"
+					  << "Position:   " << result.position() << "\n"
+					  << "Rotation:   " << result.orientation() << " deg\n"
+					  << "Error:      " << ToString(result.status()) << "\n";
 
 			auto printOptional = [](const char* key, const std::string& v) {
 				if (!v.empty())
 					std::cout << key << v << "\n";
 			};
 
-			printOptional("EC Level: ", ToUtf8(result.ecLevel()));
+			printOptional("EC Level:   ", ToUtf8(result.ecLevel()));
 
 			if (result.lineCount())
-				std::cout << "Lines:    " << result.lineCount() << "\n";
+				std::cout << "Lines:      " << result.lineCount() << "\n";
 
 			if ((BarcodeFormat::EAN13 | BarcodeFormat::EAN8 | BarcodeFormat::UPCA | BarcodeFormat::UPCE)
 					.testFlag(result.format())) {
-				printOptional("Country:  ", GTIN::LookupCountryIdentifier(ToUtf8(result.text()), result.format()));
-				printOptional("Add-On:   ", GTIN::EanAddOn(result));
-				printOptional("Price:    ", GTIN::Price(GTIN::EanAddOn(result)));
-				printOptional("Issue #:  ", GTIN::IssueNr(GTIN::EanAddOn(result)));
+				printOptional("Country:    ", GTIN::LookupCountryIdentifier(ToUtf8(result.text()), result.format()));
+				printOptional("Add-On:     ", GTIN::EanAddOn(result));
+				printOptional("Price:      ", GTIN::Price(GTIN::EanAddOn(result)));
+				printOptional("Issue #:    ", GTIN::IssueNr(GTIN::EanAddOn(result)));
 			} else if (result.format() == BarcodeFormat::ITF && result.text().length() == 14) {
-				printOptional("Country:  ", GTIN::LookupCountryIdentifier(ToUtf8(result.text()), result.format()));
+				printOptional("Country:    ", GTIN::LookupCountryIdentifier(ToUtf8(result.text()), result.format()));
 			}
 
 			if (result.isPartOfSequence())

--- a/test/samples/itf-1/1.result.txt
+++ b/test/samples/itf-1/1.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]I1

--- a/test/samples/itf-1/2.result.txt
+++ b/test/samples/itf-1/2.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]I1

--- a/test/samples/itf-1/3.result.txt
+++ b/test/samples/itf-1/3.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]I0

--- a/test/samples/itf-1/5.result.txt
+++ b/test/samples/itf-1/5.result.txt
@@ -1,0 +1,1 @@
+symbologyIdentifier=]I0


### PR DESCRIPTION
Closes #214 (if done after [PR #296](https://github.com/nu-book/zxing-cpp/pull/296)).

Implements symbologyIdentifier for ITF.

Also adds `assumeITFCheckDigit` to `DecodeHints` to allow validation of ITF-14 check digit (analogously to `assumeCode39CheckDigit`).

Also adds reporting of `symbolIdentifier` to "example/ZXingReader.cpp".