### PR TITLE
Suppress some MSVC warnings on Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 if (MSVC)
     option (LINK_CPP_STATICALLY "MSVC only, link standard library statically (/MT and /MTd)" OFF)
 
-    add_definitions (-DUNICODE -D_UNICODE)
+    add_definitions (-DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
     set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Oi /GS-")
     set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GS-")

--- a/core/src/GTIN.cpp
+++ b/core/src/GTIN.cpp
@@ -18,6 +18,7 @@
 #include "GTIN.h"
 
 #include "Result.h"
+#include "TextUtfEncoding.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -217,7 +218,7 @@ std::string EanAddOn(const Result& result)
 		return {};
 	auto txt = result.text();
 	auto pos = txt.find(L' ');
-	return std::string(pos == std::wstring::npos ? txt.end() : txt.begin() + pos + 1, txt.end());
+	return pos != std::wstring::npos ? TextUtfEncoding::ToUtf8(txt.substr(pos + 1)) : std::string();
 }
 
 std::string IssueNr(const std::string& ean2AddOn)

--- a/example/ZXingQtReader.h
+++ b/example/ZXingQtReader.h
@@ -121,7 +121,7 @@ public:
 	explicit Result(ZXing::Result&& r) : ZXing::Result(std::move(r)) {
 		_text = QString::fromWCharArray(ZXing::Result::text().c_str());
 		_rawBytes = QByteArray(reinterpret_cast<const char*>(ZXing::Result::rawBytes().data()),
-							   ZXing::Result::rawBytes().size());
+							   Size(ZXing::Result::rawBytes()));
 		auto& pos = ZXing::Result::position();
 		auto qp = [&pos](int i) { return QPoint(pos[i].x, pos[i].y); };
 		_position = {qp(0), qp(1), qp(2), qp(3)};

--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -101,7 +101,7 @@ void drawLine(const ImageView& image, PointI a, PointI b)
 	int steps = maxAbsComponent(b - a);
 	PointF dir = bresenhamDirection(PointF(b - a));
 	for (int i = 0; i < steps; ++i) {
-		auto p = centered(a + i * dir);
+		auto p = PointI(centered(a + i * dir));
 		*((uint32_t*)image.data(p.x, p.y)) = 0xff0000ff;
 	}
 }

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -16,12 +16,6 @@ if (BUILD_READERS)
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
     )
 
-if (MSVC)
-    target_compile_options(ReaderTest PRIVATE
-        -D_CRT_SECURE_NO_WARNINGS
-    )
-endif()
-
     add_test(NAME ReaderTest COMMAND ReaderTest ${CMAKE_CURRENT_SOURCE_DIR}/../samples)
 endif()
 


### PR DESCRIPTION
- GINT: convert wstring -> string using TextUtfEncoding (C4244 possible loss of data)
- ZXingQtReader/ZXingReader: some casts (C4244)
- example/blackbox CMakeLists: define _CRT_SECURE_NO_WARNINGS (C4996 unsafe func)