### PR TITLE
android: draw result points/position on screen

### DIFF
--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/DetectorView.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/DetectorView.kt
@@ -1,0 +1,48 @@
+package com.example.zxingcppdemo
+
+import android.content.Context
+import android.graphics.*
+import android.util.AttributeSet
+import android.view.View
+
+class DetectorView : View {
+	private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+	private val path = Path()
+
+	init {
+		paint.style = Paint.Style.STROKE
+		paint.color = 0xffffffff.toInt()
+		paint.strokeWidth = context.resources.displayMetrics.density
+	}
+
+	constructor(context: Context, attrs: AttributeSet) :
+			super(context, attrs)
+
+	constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) :
+			super(context, attrs, defStyleAttr)
+
+	fun update(points: List<PointF>? = null) {
+		path.apply {
+			rewind()
+			if (!points.isNullOrEmpty()) {
+				moveTo(points[0])
+				val size = points.size
+				for (i in 1 until size) {
+					lineTo(points[i])
+				}
+				close()
+			}
+		}
+		invalidate()
+	}
+
+	override fun onDraw(canvas: Canvas) {
+		canvas.drawColor(0, PorterDuff.Mode.CLEAR)
+		if (!path.isEmpty) {
+			canvas.drawPath(path, paint)
+		}
+	}
+}
+
+private fun Path.lineTo(point: PointF) = lineTo(point.x, point.y)
+private fun Path.moveTo(point: PointF) = moveTo(point.x, point.y)

--- a/wrappers/android/app/src/main/res/layout-land/activity_camera.xml
+++ b/wrappers/android/app/src/main/res/layout-land/activity_camera.xml
@@ -13,6 +13,11 @@
         android:layout_height="match_parent"
         app:scaleType="fitCenter" />
 
+    <com.example.zxingcppdemo.DetectorView
+        android:id="@+id/detectorView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
     <View
         android:id="@+id/cropRect"
         android:layout_width="0dp"

--- a/wrappers/android/app/src/main/res/layout/activity_camera.xml
+++ b/wrappers/android/app/src/main/res/layout/activity_camera.xml
@@ -13,6 +13,11 @@
         android:layout_height="match_parent"
         app:scaleType="fitCenter" />
 
+    <com.example.zxingcppdemo.DetectorView
+        android:id="@+id/detectorView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
     <View
         android:id="@+id/cropRect"
         android:layout_width="0dp"


### PR DESCRIPTION
To highlight a detected barcode on the screen.

I changed as little as possible, but I had to touch `image2View` to make it handle 180 degree rotations of arbitrary coordinates. This is important when using the Java implementation for 180 degree image rotations (which is usually one of the landscape orientations).

Please note that scanning 1D barcodes just draws one line as ZXing return just two result points for them.

Also, the result points from the Java implementation do not match exactly with the C++ implementation, at least not for QR Codes. But the difference is probably intentional, I guess.

This code could be optimized a little by storing the result of the scale and offset calculation in `image2View` in the object instance to avoid having to recalculate them for every point.
