### PR TITLE
android: remove clearing overlay canvas

### DIFF
--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/PreviewOverlay.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/PreviewOverlay.kt
@@ -63,7 +63,6 @@ class PreviewOverlay constructor(context: Context, attributeSet: AttributeSet?) 
 
 	override fun onDraw(canvas: Canvas) {
 		canvas.apply {
-			drawColor(0, PorterDuff.Mode.CLEAR)
 			// draw the cropRect, which is relative to the original image orientation
 			save()
 			if (rotation == 90) {


### PR DESCRIPTION
Fixing a bug I introduced 😬 

Clearing the Canvas is unnecessary, and doing so clears out the camera frame when the underlying surface is the same, which it is for some devices/graphics drivers (just noticed this on a Xiaomi Mi A2 Lite).

Besides, I really like that you moved drawing the crop rectangle into the overlay, and made use of the canvas matrix to map the coordinates. So much simpler 👍 

