### PR TITLE
Fix threshold test in VS2019 Debug build.

### DIFF
--- a/test/unit/ThresholdBinarizerTest.cpp
+++ b/test/unit/ThresholdBinarizerTest.cpp
@@ -41,7 +41,7 @@ static BitMatrix ParseBitMatrix(const std::string& str, const int width)
 // Helper to convert a BitMatrix into a black/white ImageView
 static ImageView getImageView(std::vector<uint8_t> &buf, const BitMatrix &bits)
 {
-	buf.reserve(bits.width() * bits.height());
+	buf.resize(bits.width() * bits.height());
 	for (int r = 0; r < bits.height(); r++) {
 		const int k = r * bits.width();
 		for (int c = 0; c < bits.width(); c++) {


### PR DESCRIPTION
The setup code for the test creates a buffer using vector's reserve.  This works for the release build but in debug build VS uses checked iterators which causes an error to be generated when the vector is accessed using [].  I changed reserve to resize.