### PR TITLE
Fix PDF417 infinite loop

### DIFF
--- a/core/src/pdf417/PDFDetector.cpp
+++ b/core/src/pdf417/PDFDetector.cpp
@@ -162,10 +162,11 @@ FindRowsWithPattern(const BitMatrix& matrix, int height, int width, int startRow
 {
 	bool found = false;
 	int startPos, endPos;
+	int minStartRow = startRow;
 	std::vector<int> counters(pattern.size(), 0);
 	for (; startRow < height; startRow += ROW_STEP) {
 		if (FindGuardPattern(matrix, startColumn, startRow, width, false, pattern, counters, startPos, endPos)) {
-			while (startRow > 0) {
+			while (startRow > minStartRow + 1) {
 				if (!FindGuardPattern(matrix, startColumn, --startRow, width, false, pattern, counters, startPos, endPos)) {
 					startRow++;
 					break;


### PR DESCRIPTION
Backstepping should not violate `startRow`.
Fixes #316 

![bug-vis](https://user-images.githubusercontent.com/21275667/164171685-4b185c75-766a-48d3-9e95-2b01dfbc4290.png)

In the image above, red & blue polygons are the detected PDF417 regions. The green line is the 171st row. This change restricts the backstepping so that it can find the two regions below the green line. Before this fix, the program would find the previous 2 regions again and thus end up in an infinite loop.