### PR TITLE
Fixed comparison bug in MultiFormatReader.cpp

### DIFF
--- a/core/src/MultiFormatReader.cpp
+++ b/core/src/MultiFormatReader.cpp
@@ -90,7 +90,7 @@ Results MultiFormatReader::readMultiple(const BinaryBitmap& image, int maxSymbol
 	std::sort(res.begin(), res.end(), [](const Result& l, const Result& r) {
 		auto lp = l.position().topLeft();
 		auto rp = r.position().topLeft();
-		return lp.y < rp.y || (lp.y == rp.y && lp.x <= rp.x);
+		return lp.y < rp.y || (lp.y == rp.y && lp.x < rp.x);
 	});
 
 	return res;


### PR DESCRIPTION
This PR fixes a potential crash issue caused by an invalid comparison happening the `MultiFormatReader.cpp`. The comparison uses the `<=` operator when comparing the x position of barcodes, which could, if the positions are identical, result in an invalid comparison result were `a > b == b > a`. 
Depending on the compiler and sort implementation, this could cause a crash due to the object trying to be moved onto itself.

Changing the comparison operator to `<` fixes this problem.