### PR TITLE
Generate the PDF417 ratio table at compile time

### DIFF
--- a/core/src/pdf417/PDFCodewordDecoder.cpp
+++ b/core/src/pdf417/PDFCodewordDecoder.cpp
@@ -27,7 +27,7 @@
 namespace ZXing {
 namespace Pdf417 {
 
-static const int SYMBOL_COUNT = 2787;
+static constexpr const int SYMBOL_COUNT = 2787;
 
 
 /**
@@ -35,7 +35,7 @@ static const int SYMBOL_COUNT = 2787;
 * specification. The index of a symbol in this table corresponds to the
 * index into the codeword table.
 */
-const std::array<int, 2787> SYMBOL_TABLE = {
+static constexpr const std::array<int, 2787> SYMBOL_TABLE = {
 	0x1025e, 0x1027a, 0x1029e, 0x102bc, 0x102f2, 0x102f4, 0x1032e, 0x1034e, 0x1035c, 0x10396, 0x103a6, 0x103ac,
 	0x10422, 0x10428, 0x10436, 0x10442, 0x10444, 0x10448, 0x10450, 0x1045e, 0x10466, 0x1046c, 0x1047a, 0x10482,
 	0x1049e, 0x104a0, 0x104bc, 0x104c6, 0x104d8, 0x104ee, 0x104f2, 0x104f4, 0x10504, 0x10508, 0x10510, 0x1051e,
@@ -274,7 +274,7 @@ const std::array<int, 2787> SYMBOL_TABLE = {
 /**
 * This table contains to codewords for all symbols.
 */
-static const std::array<uint16_t, 2787> CODEWORD_TABLE = {
+static constexpr const std::array<uint16_t, 2787> CODEWORD_TABLE = {
 	2627, 1819, 2622, 2621, 1813, 1812, 2729, 2724, 2723, 2779, 2774, 2773, 902, 896, 908, 868, 865, 861, 859, 2511,
 	873, 871, 1780, 835, 2493, 825, 2491, 842, 837, 844, 1764, 1762, 811, 810, 809, 2483, 807, 2482, 806, 2480, 815,
 	814, 813, 812, 2484, 817, 816, 1745, 1744, 1742, 1746, 2655, 2637, 2635, 2626, 2625, 2623, 2628, 1820, 2752,
@@ -423,7 +423,8 @@ using ModuleBitCountType = std::array<int, CodewordDecoder::BARS_IN_MODULE>;
 
 static const RatioTableType& GetRatioTable()
 {
-	auto initTable = [](RatioTableType& table) -> RatioTableType& {
+	static constexpr RatioTableType table{[]() constexpr {
+		RatioTableType table{};
 		for (int i = 0; i < SYMBOL_COUNT; i++) {
 			int currentSymbol = SYMBOL_TABLE[i];
 			int currentBit = currentSymbol & 0x1;
@@ -438,11 +439,9 @@ static const RatioTableType& GetRatioTable()
 			}
 		}
 		return table;
-	};
+	}()};
 
-	static RatioTableType table;
-	static const auto& ref = initTable(table);
-	return ref;
+	return table;
 }
 
 static ModuleBitCountType SampleBitCounts(const ModuleBitCountType& moduleBitCount)

--- a/core/src/pdf417/PDFCodewordDecoder.h
+++ b/core/src/pdf417/PDFCodewordDecoder.h
@@ -28,13 +28,13 @@ namespace Pdf417 {
 class CodewordDecoder
 {
 public:
-	static const int NUMBER_OF_CODEWORDS = 929;
+	static constexpr const int NUMBER_OF_CODEWORDS = 929;
 	// Maximum Codewords (Data + Error).
-	static const int MAX_CODEWORDS_IN_BARCODE = NUMBER_OF_CODEWORDS - 1;
+	static constexpr const int MAX_CODEWORDS_IN_BARCODE = NUMBER_OF_CODEWORDS - 1;
 	// One left row indication column + max 30 data columns + one right row indicator column
 	//public static final int MAX_CODEWORDS_IN_ROW = 32;
-	static const int MODULES_IN_CODEWORD = 17;
-	static const int BARS_IN_MODULE = 8;
+	static constexpr const int MODULES_IN_CODEWORD = 17;
+	static constexpr const int BARS_IN_MODULE = 8;
 
 	/**
 	* @param symbol encoded symbol to translate to a codeword


### PR DESCRIPTION
This not only avoids the entire computation at runtime, it also moves the
required memory from .bss (allocated at runtime per process) to .rodata
(shared between all processes and only loaded on demand), cutting down the
.bss section size by about 90%.