### PR TITLE
PDFScanningDecoder::VerifyCodewordCount(): check codewords[0] exactly matches array size; add test

### DIFF
--- a/core/src/pdf417/PDFScanningDecoder.cpp
+++ b/core/src/pdf417/PDFScanningDecoder.cpp
@@ -5,23 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "PDFScanningDecoder.h"
-#include "PDFBoundingBox.h"
-#include "PDFDetectionResultColumn.h"
-#include "PDFCodewordDecoder.h"
-#include "PDFBarcodeMetadata.h"
-#include "PDFDetectionResult.h"
-#include "PDFBarcodeValue.h"
-#include "PDFDecodedBitStreamParser.h"
-#include "PDFModulusGF.h"
-#include "ResultPoint.h"
-#include "ZXNullable.h"
+
 #include "BitMatrix.h"
 #include "DecoderResult.h"
+#include "PDFBarcodeMetadata.h"
+#include "PDFBarcodeValue.h"
+#include "PDFCodewordDecoder.h"
+#include "PDFDetectionResult.h"
+#include "PDFDecodedBitStreamParser.h"
+#include "PDFModulusGF.h"
 #include "ZXTestSupport.h"
-
-#include <cstdlib>
-#include <array>
-#include <algorithm>
 
 namespace ZXing {
 namespace Pdf417 {

--- a/core/src/pdf417/PDFScanningDecoder.cpp
+++ b/core/src/pdf417/PDFScanningDecoder.cpp
@@ -555,8 +555,10 @@ static bool VerifyCodewordCount(std::vector<int>& codewords, int numECCodewords)
 	if (numberOfCodewords > Size(codewords)) {
 		return false;
 	}
-	if (numberOfCodewords == 0) {
-		// Reset to the length of the array - 8 (Allow for at least level 3 Error Correction (8 Error Codewords)
+
+	assert(numECCodewords >= 2);
+	if (numberOfCodewords + numECCodewords != Size(codewords)) {
+		// Reset to the length of the array less number of Error Codewords
 		if (numECCodewords < Size(codewords)) {
 			codewords[0] = Size(codewords) - numECCodewords;
 		}

--- a/core/src/pdf417/PDFScanningDecoder.h
+++ b/core/src/pdf417/PDFScanningDecoder.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <string>
-
 namespace ZXing {
 
 class BitMatrix;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable (UnitTest
     pdf417/PDF417DecoderTest.cpp
     pdf417/PDF417ErrorCorrectionTest.cpp
     pdf417/PDF417HighLevelEncoderTest.cpp
+    pdf417/PDF417ScanningDecoderTest.cpp
     pdf417/PDF417WriterTest.cpp
 )
 

--- a/test/unit/pdf417/PDF417ScanningDecoderTest.cpp
+++ b/test/unit/pdf417/PDF417ScanningDecoderTest.cpp
@@ -1,0 +1,56 @@
+/*
+* Copyright 2022 gitlost
+*/
+// SPDX-License-Identifier: Apache-2.0
+
+#include "DecoderResult.h"
+#include "pdf417/PDFScanningDecoder.h"
+
+#include "gtest/gtest.h"
+
+namespace ZXing::Pdf417 {
+	DecoderResult DecodeCodewords(std::vector<int>& codewords, int ecLevel, const std::vector<int>& erasures);
+}
+
+using namespace ZXing;
+using namespace ZXing::Pdf417;
+
+// Shorthand for DecodeCodewords()
+static DecoderResult decode(std::vector<int>& codewords, int ecLevel = 0)
+{
+	std::vector<int> erasures;
+	auto result = DecodeCodewords(codewords, ecLevel, erasures);
+
+	return result;
+}
+
+TEST(PDF417ScanningDecoderTest, BadSymbolLengthDescriptor)
+{
+	{
+		std::vector<int> codewords = { 4, 1, 449, 394 }; // 4 should be 2
+
+		auto result = decode(codewords);
+
+		EXPECT_TRUE(result.isValid());
+		EXPECT_EQ(result.text(), L"AB");
+		EXPECT_EQ(codewords[0], 2);
+	}
+	{
+		std::vector<int> codewords = { 1, 1, 800, 351 }; // 1 should be 2
+
+		auto result = decode(codewords);
+
+		EXPECT_TRUE(result.isValid());
+		EXPECT_EQ(result.text(), L"AB");
+		EXPECT_EQ(codewords[0], 2);
+	}
+	{
+		std::vector<int> codewords = { 0, 1, 917, 27 }; // 0 should be 2
+
+		auto result = decode(codewords);
+
+		EXPECT_TRUE(result.isValid());
+		EXPECT_EQ(result.text(), L"AB");
+		EXPECT_EQ(codewords[0], 2);
+	}
+}


### PR DESCRIPTION
For `PDFScanningDecoder::VerifyCodewordCount()` check `codewords[0]` exactly matches array size; add test.

Also remove some unnecessary includes, sort.