### PR TITLE
ODDatabarReader::ConstructText(): strip GS1 Composite 2D linkage flag

### DIFF
--- a/core/src/oned/ODDataBarReader.cpp
+++ b/core/src/oned/ODDataBarReader.cpp
@@ -135,6 +135,10 @@ static std::string ConstructText(Pair leftPair, Pair rightPair)
 {
 	auto value = [](Pair p) { return 1597 * p.left.value + p.right.value; };
 	auto res = 4537077LL * value(leftPair) + value(rightPair);
+	if (res >= 10000000000000LL) { // Strip 2D linkage flag (GS1 Composite) if any (ISO/IEC 24724:2011 Section 5.2.3)
+		res -= 10000000000000LL;
+		assert(res <= 9999999999999LL); // 13 digits
+	}
 	auto txt = ToString(res, 13);
 	return txt + GTIN::ComputeCheckDigit(txt);
 }

--- a/core/src/oned/ODDataBarReader.cpp
+++ b/core/src/oned/ODDataBarReader.cpp
@@ -204,7 +204,7 @@ Result DataBarReader::decodePattern(int rowNumber, PatternView& next,
 			}
 #endif
 
-	// guaratee progress (see loop in ODReader.cpp)
+	// guarantee progress (see loop in ODReader.cpp)
 	next = {};
 
 	return {};

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -42,12 +42,13 @@ add_executable (UnitTest
     oned/ODCode93WriterTest.cpp
     oned/ODCode128ReaderTest.cpp
     oned/ODCode128WriterTest.cpp
+    oned/ODDataBarReaderTest.cpp
+    oned/ODDataBarExpandedBitDecoderTest.cpp
     oned/ODEAN8WriterTest.cpp
     oned/ODEAN13WriterTest.cpp
     oned/ODITFWriterTest.cpp
     oned/ODUPCAWriterTest.cpp
     oned/ODUPCEWriterTest.cpp
-    oned/ODDataBarExpandedBitDecoderTest.cpp
     qrcode/MQRDecoderTest.cpp
     qrcode/QRBitMatrixParserTest.cpp
     qrcode/QRDataMaskTest.cpp

--- a/test/unit/oned/ODDataBarReaderTest.cpp
+++ b/test/unit/oned/ODDataBarReaderTest.cpp
@@ -1,0 +1,38 @@
+/*
+* Copyright 2022 gitlost
+*/
+// SPDX-License-Identifier: Apache-2.0
+
+#include "oned/ODDataBarReader.h"
+
+#include "DecodeHints.h"
+#include "Result.h"
+
+#include "gtest/gtest.h"
+
+using namespace ZXing;
+using namespace ZXing::OneD;
+
+// Helper to call decodePattern()
+static Result parse(PatternRow row, DecodeHints hints = {})
+{
+	DataBarReader reader(hints);
+
+	row.insert(row.begin(), { 1, 1 }); // Left guard
+	row.insert(row.end(), { 1, 1 }); // Right guard
+
+	std::unique_ptr<RowReader::DecodingState> state;
+	PatternView next(row);
+	return reader.decodePattern(0, next, state);
+}
+
+TEST(ODDataBarReaderTest, Composite)
+{
+	{
+		// With 2D linkage flag (GS1 Composite) in checksum
+		PatternRow row = { 2, 3, 1, 2, 1, 2, 4, 1, 3, 3, 7, 1, 1, 3, 1, 2, 1, 1, 1, 4, 2, 4, 1, 1, 2, 3, 1, 1, 2, 1, 1, 2, 8, 3, 3, 2, 2, 1, 4, 1, 1, 2 };
+		Result result = parse(row);
+		EXPECT_TRUE(result.isValid());
+		EXPECT_EQ(result.text(), "01234567890128");
+	}
+}


### PR DESCRIPTION
For `ODDatabarReader::ConstructText()` strip GS1 Composite 2D linkage flag from checksum if any (stops `ToString()` throwing an exception and at least allows the linear part of GS1 Composite symbols to be returned); add test.

TODO: decode GS1 Composite barcodes!

Also comment typo.