### PR TITLE
MCDecoder: allow for dodgy data in primary message

### DIFF
--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -122,25 +122,26 @@ static int GetBit(int bit, const ByteArray& bytes)
 	return (bytes[bit / 6] & (1 << (5 - (bit % 6)))) == 0 ? 0 : 1;
 }
 
-static int GetInt(const ByteArray& bytes, const ByteArray& x)
+static unsigned int GetInt(const ByteArray& bytes, const ByteArray& x)
 {
 	int len = Size(x);
-	int val = 0;
+	unsigned int val = 0;
 	for (int i = 0; i < len; i++)
 		val += GetBit(x[i], bytes) << (len - i - 1);
 
 	return val;
 }
 
-static int GetPostCode2(const ByteArray& bytes)
+static unsigned int GetPostCode2(const ByteArray& bytes)
 {
-	return GetInt(bytes,
-				  {33, 34, 35, 36, 25, 26, 27, 28, 29, 30, 19, 20, 21, 22, 23, 24, 13, 14, 15, 16, 17, 18, 7, 8, 9, 10, 11, 12, 1, 2});
+	return std::min(GetInt(bytes,
+					{33, 34, 35, 36, 25, 26, 27, 28, 29, 30, 19, 20, 21, 22, 23, 24, 13, 14, 15, 16, 17, 18, 7, 8, 9, 10, 11, 12, 1, 2}),
+					999999999U);
 }
 
-static int GetPostCode2Length(const ByteArray& bytes)
+static unsigned int GetPostCode2Length(const ByteArray& bytes)
 {
-	return GetInt(bytes, {39, 40, 41, 42, 31, 32});
+	return std::min(GetInt(bytes, {39, 40, 41, 42, 31, 32}), 9U);
 }
 
 static std::string GetPostCode3(const ByteArray& bytes)
@@ -155,14 +156,14 @@ static std::string GetPostCode3(const ByteArray& bytes)
 	};
 }
 
-static int GetCountry(const ByteArray& bytes)
+static unsigned int GetCountry(const ByteArray& bytes)
 {
-	return GetInt(bytes, {53, 54, 43, 44, 45, 46, 47, 48, 37, 38});
+	return std::min(GetInt(bytes, {53, 54, 43, 44, 45, 46, 47, 48, 37, 38}), 999U);
 }
 
-static int GetServiceClass(const ByteArray& bytes)
+static unsigned int GetServiceClass(const ByteArray& bytes)
 {
-	return GetInt(bytes, {55, 56, 57, 58, 59, 60, 49, 50, 51, 52});
+	return std::min(GetInt(bytes, {55, 56, 57, 58, 59, 60, 49, 50, 51, 52}), 999U);
 }
 
 /**


### PR DESCRIPTION
For `MCDecoder` allow for dodgy data in primary message, including postcode data/length mismatches and out-of-range postcode/country/class values.