### PR TITLE
Fix C4996 when compiled with MSVC

### DIFF
--- a/core/src/ByteArray.h
+++ b/core/src/ByteArray.h
@@ -38,11 +38,13 @@ inline std::string ToHex(const ByteArray& bytes)
 	std::string res(bytes.size() * 3, ' ');
 
 	for (size_t i = 0; i < bytes.size(); ++i)
+	{
 #ifdef _MSC_VER
-		sprintf_s(&res[i * 3], 3, "%02X ", bytes[i]);
+		sprintf_s(&res[i * 3], 4, "%02X ", bytes[i]);
 #else
 		sprintf(&res[i * 3], "%02X ", bytes[i]);
 #endif
+	}
 
 	return res.substr(0, res.size()-1);
 }

--- a/core/src/ByteArray.h
+++ b/core/src/ByteArray.h
@@ -38,7 +38,11 @@ inline std::string ToHex(const ByteArray& bytes)
 	std::string res(bytes.size() * 3, ' ');
 
 	for (size_t i = 0; i < bytes.size(); ++i)
+#ifdef _MSC_VER
+		sprintf_s(&res[i * 3], 3, "%02X ", bytes[i]);
+#else
 		sprintf(&res[i * 3], "%02X ", bytes[i]);
+#endif
 
 	return res.substr(0, res.size()-1);
 }


### PR DESCRIPTION
ByteArray.h is a installed header and it triggers MSVC warning C4996 when used in other projects. This PR fixes it by using MSVC-specific alternatives when they are present.